### PR TITLE
Fixes https://github.com/androidx/gcp-gradle-build-cache/issues/19

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,10 @@
+# Release notes for GCP backed Gradle Remote Cache
+
+## 1.0.0-alpha03
+
+- Fixes issue [19](https://github.com/androidx/gcp-gradle-build-cache/issues/19).
+    - Remove retry-ing of RPCs.
+    - When writes fail, we fail silently and treat subsequent reads as a cache-miss.
+    - Set the `chunkSize` for reads to equal the size of the `Blob`.
+      This way, we only make 1 RPC per blob input stream. This is safe because
+      the size of the objects in cache are not very large.

--- a/gcpbuildcache/build.gradle.kts
+++ b/gcpbuildcache/build.gradle.kts
@@ -54,7 +54,7 @@ gradlePlugin {
 }
 
 group = "androidx.build.gradle.gcpbuildcache"
-version = "1.0.0-alpha02"
+version = "1.0.0-alpha03"
 
 testing {
     suites {


### PR DESCRIPTION
- Remove retry-ing of failed RPCs.
- When writes fail, we fail silently and treat subsequent reads as a cache-miss.
- Set the `chunkSize` for reads to equal the size of the `Blob`.
  This way, we only make 1 RPC per blob input stream. This is safe because
  the size of the objects in cache are not very large.
- Added Release notes.