### PR TITLE
Handle `StorageException`s when loading blobs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In your `settings.gradle.kts` file add the following
 
 ```kotlin
 plugins {
-    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-alpha03"
+    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-alpha04"
 }
 
 import androidx.build.gradle.gcpbuildcache.GcpBuildCache
@@ -36,7 +36,7 @@ If you are using Groovy, then you should do the following:
 
 ```groovy
 plugins {
-    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-alpha03"
+    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-alpha04"
 }
 
 import androidx.build.gradle.gcpbuildcache.GcpBuildCache

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release notes for GCP backed Gradle Remote Cache
 
+## 1.0.0-alpha04
+
+- Handles exceptions when fetching `BlobInfo`s and `ReadChannel`s from the storage service.
+
 ## 1.0.0-alpha03
 
 - Fixes issue [19](https://github.com/androidx/gcp-gradle-build-cache/issues/19).

--- a/gcpbuildcache/build.gradle.kts
+++ b/gcpbuildcache/build.gradle.kts
@@ -54,7 +54,7 @@ gradlePlugin {
 }
 
 group = "androidx.build.gradle.gcpbuildcache"
-version = "1.0.0-alpha03"
+version = "1.0.0-alpha04"
 
 testing {
     suites {

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageService.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageService.kt
@@ -105,11 +105,16 @@ internal class GcpStorageService(
 
         private fun load(storage: StorageOptions?, blobId: BlobId): ReadChannel? {
             if (storage == null) return null
-            val blob = storage.service.get(blobId) ?: return null
-            val reader = blob.reader()
-            // We don't expect to store objects larger than Int.MAX_VALUE
-            reader.setChunkSize(blob.size.toInt())
-            return reader
+            return try {
+                val blob = storage.service.get(blobId) ?: return null
+                val reader = blob.reader()
+                // We don't expect to store objects larger than Int.MAX_VALUE
+                reader.setChunkSize(blob.size.toInt())
+                reader
+            } catch (storageException: StorageException) {
+                logger.debug("Unable to load Blob ($blobId)", storageException)
+                null
+            }
         }
 
         private fun store(storage: StorageOptions?, blobId: BlobId, contents: ByteArray): Boolean {


### PR DESCRIPTION
* Fetching blobs and `ReadChannel`s can fail. Treat them as cache misses.