### PR TITLE
Bring back retries when downloading blobs from the Storage cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In your `settings.gradle.kts` file add the following
 
 ```kotlin
 plugins {
-    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-alpha04"
+    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-alpha05"
 }
 
 import androidx.build.gradle.gcpbuildcache.GcpBuildCache
@@ -36,7 +36,7 @@ If you are using Groovy, then you should do the following:
 
 ```groovy
 plugins {
-    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-alpha04"
+    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-alpha05"
 }
 
 import androidx.build.gradle.gcpbuildcache.GcpBuildCache

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,12 @@
 # Release notes for GCP backed Gradle Remote Cache
 
+## 1.0.0-alpha05
+
+- Downloads `Blob`s to an intermediate `Buffer` or a `File` depending on the size of the blob.
+- The underlying `FileHandleInputStream` gets cleaned up automatically after the `InputStream` is closed.
+- This way we can avoid flakes from the build cache, that is caused by intermittent `StorageException`s 
+- Retry on fetches given they are being fetched to an intermediate location.
+
 ## 1.0.0-alpha04
 
 - Handles exceptions when fetching `BlobInfo`s and `ReadChannel`s from the storage service.

--- a/gcpbuildcache/build.gradle.kts
+++ b/gcpbuildcache/build.gradle.kts
@@ -54,7 +54,7 @@ gradlePlugin {
 }
 
 group = "androidx.build.gradle.gcpbuildcache"
-version = "1.0.0-alpha04"
+version = "1.0.0-alpha05"
 
 testing {
     suites {

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/FileHandleInputStream.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/FileHandleInputStream.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package androidx.build.gradle.gcpbuildcache
+
+import java.io.File
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * An input stream that keeps track of the file handles, so they can be cleaned up when the
+ * [FileHandleInputStream] is closed.
+ */
+internal class FileHandleInputStream(private val file: File) : InputStream() {
+    private val inputStream by lazy {
+        file.inputStream()
+    }
+
+    override fun read(): Int {
+        return inputStream.read()
+    }
+
+    override fun close() {
+        super.close()
+        try {
+            inputStream.close()
+        } finally {
+            check(file.delete()) {
+                "Unable to delete $file"
+            }
+        }
+    }
+
+    companion object {
+        fun Path.handleInputStream(): InputStream {
+            return FileHandleInputStream(this.toFile())
+        }
+
+        fun create(): Path {
+            val timestamp = System.nanoTime()
+            return Files.createTempFile("gradleCache", "$timestamp")
+        }
+    }
+}

--- a/gcpbuildcache/src/test/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageServiceTest.kt
+++ b/gcpbuildcache/src/test/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageServiceTest.kt
@@ -35,7 +35,8 @@ class GcpStorageServiceTest {
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
             isPush = true,
-            isEnabled = true
+            isEnabled = true,
+            sizeThreshold = 0L
         )
         storageService.use {
             val cacheKey = "test-store.txt"
@@ -54,7 +55,8 @@ class GcpStorageServiceTest {
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
             isPush = true,
-            isEnabled = true
+            isEnabled = true,
+            sizeThreshold = 0L
         )
         storageService.use {
             val cacheKey = "test-load.txt"
@@ -76,7 +78,8 @@ class GcpStorageServiceTest {
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
             isPush = false,
-            isEnabled = true
+            isEnabled = true,
+            sizeThreshold = 0L
         )
         storageService.use {
             val cacheKey = "test-store-no-push.txt"
@@ -94,14 +97,16 @@ class GcpStorageServiceTest {
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
             isPush = true,
-            isEnabled = true
+            isEnabled = true,
+            sizeThreshold = 0L
         )
         val readOnlyStorageService = GcpStorageService(
             projectId = PROJECT_ID,
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath)),
             isPush = false,
-            isEnabled = true
+            isEnabled = true,
+            sizeThreshold = 0L
         )
         storageService.use {
             readOnlyStorageService.use {
@@ -125,7 +130,8 @@ class GcpStorageServiceTest {
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
             isPush = true,
-            isEnabled = false
+            isEnabled = false,
+            sizeThreshold = 0L
         )
         storageService.use {
             val cacheKey = "test-store-disabled.txt"


### PR DESCRIPTION
* When handing the `InputStream` to Gradle, we cannot have the
`InputStream` flake due to problems fetching blobs, so save them in a
temporary buffer / file depending on the size.

* This way once we have the `Buffer`, we can pass it to Gradle and avoid flakes.
* a `FileHandleInputStream` also cleans up after it has been used.