### PR TITLE
Bundle core project inside each respective implementation

### DIFF
--- a/gcpbuildcache/build.gradle.kts
+++ b/gcpbuildcache/build.gradle.kts
@@ -22,8 +22,14 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
+// Bundle core library directly as we only get to publish one jar per plugin in Gradle Plugin Portal
+sourceSets.main {
+    java.srcDir("../core/src/main/kotlin")
+}
+
 dependencies {
-    implementation(project(":core"))
+    implementation(libs.retrofit.core)
+    implementation(libs.retrofit.converter.gson)
     implementation(libs.google.cloud.storage)
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.converter.gson)
@@ -46,7 +52,7 @@ gradlePlugin {
 }
 
 group = "androidx.build.gradle.gcpbuildcache"
-version = "1.0.0-beta02"
+version = "1.0.0-beta03"
 
 testing {
     suites {

--- a/gcpbuildcache/build.gradle.kts
+++ b/gcpbuildcache/build.gradle.kts
@@ -28,8 +28,6 @@ sourceSets.main {
 }
 
 dependencies {
-    implementation(libs.retrofit.core)
-    implementation(libs.retrofit.converter.gson)
     implementation(libs.google.cloud.storage)
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.converter.gson)

--- a/s3buildcache/build.gradle.kts
+++ b/s3buildcache/build.gradle.kts
@@ -22,8 +22,14 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
+// Bundle core library directly as we only get to publish one jar per plugin in Gradle Plugin Portal
+sourceSets.main {
+    java.srcDir("../core/src/main/kotlin")
+}
+
 dependencies {
-    implementation(project(":core"))
+    implementation(libs.retrofit.core)
+    implementation(libs.retrofit.converter.gson)
     implementation(platform(libs.amazon.bom))
     implementation(libs.amazon.s3)
     implementation(libs.amazon.sso)
@@ -51,7 +57,7 @@ gradlePlugin {
 }
 
 group = "androidx.build.gradle.s3buildcache"
-version = "1.0.0-alpha01"
+version = "1.0.0-alpha02"
 
 testing {
     suites {


### PR DESCRIPTION
Gradle plugin portal only allows us to publish a single jar per plugin implementation. Adding all the core code into each plugin to make sure these classes are available when using it.