### PR TITLE
Retry reading default GCP credentials in the expired case

### DIFF
--- a/gcpbuildcache/build.gradle.kts
+++ b/gcpbuildcache/build.gradle.kts
@@ -50,7 +50,7 @@ gradlePlugin {
 }
 
 group = "androidx.build.gradle.gcpbuildcache"
-version = "1.0.0-beta03"
+version = "1.0.0-beta04"
 
 testing {
     suites {

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpBuildCache.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpBuildCache.kt
@@ -34,4 +34,8 @@ abstract class GcpBuildCache : RemoteGradleBuildCache() {
      * The type of credentials to use to connect to the Google Cloud Platform project instance.
      */
     override var credentials: GcpCredentials = ApplicationDefaultGcpCredentials
+
+    var messageOnAuthenticationFailure: String = """Your GCP Credentials have expired.
+        Please regenerate credentials following the steps below and try again:
+        gcloud auth application-default login""".trimIndent()
 }

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpBuildCacheService.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpBuildCacheService.kt
@@ -38,6 +38,7 @@ internal class GcpBuildCacheService(
     private val projectId: String,
     private val bucketName: String,
     gcpCredentials: GcpCredentials,
+    messageOnAuthenticationFailure: String,
     isPush: Boolean,
     isEnabled: Boolean,
     inTestMode: Boolean = false
@@ -47,7 +48,7 @@ internal class GcpBuildCacheService(
         // Use an implementation backed by the File System when in test mode.
         FileSystemStorageService(bucketName, isPush, isEnabled)
     } else {
-        GcpStorageService(projectId, bucketName, gcpCredentials, isPush, isEnabled)
+        GcpStorageService(projectId, bucketName, gcpCredentials, messageOnAuthenticationFailure, isPush, isEnabled)
     }
 
     override fun close() {

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpBuildCacheServiceFactory.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpBuildCacheServiceFactory.kt
@@ -43,6 +43,7 @@ class GcpBuildCacheServiceFactory : BuildCacheServiceFactory<GcpBuildCache> {
             buildCache.projectId,
             buildCache.bucketName,
             buildCache.credentials,
+            buildCache.messageOnAuthenticationFailure,
             buildCache.isPush,
             buildCache.isEnabled
         )

--- a/gcpbuildcache/src/test/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageServiceTest.kt
+++ b/gcpbuildcache/src/test/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageServiceTest.kt
@@ -34,6 +34,7 @@ class GcpStorageServiceTest {
             projectId = PROJECT_ID,
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
+            messageOnAuthenticationFailure = "Please re-authenticate",
             isPush = true,
             isEnabled = true,
             sizeThreshold = 0L
@@ -54,6 +55,7 @@ class GcpStorageServiceTest {
             projectId = PROJECT_ID,
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
+            messageOnAuthenticationFailure = "Please re-authenticate",
             isPush = true,
             isEnabled = true,
             sizeThreshold = 0L
@@ -77,6 +79,7 @@ class GcpStorageServiceTest {
             projectId = PROJECT_ID,
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
+            messageOnAuthenticationFailure = "Please re-authenticate",
             isPush = false,
             isEnabled = true,
             sizeThreshold = 0L
@@ -96,6 +99,7 @@ class GcpStorageServiceTest {
             projectId = PROJECT_ID,
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
+            messageOnAuthenticationFailure = "Please re-authenticate",
             isPush = true,
             isEnabled = true,
             sizeThreshold = 0L
@@ -104,6 +108,7 @@ class GcpStorageServiceTest {
             projectId = PROJECT_ID,
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath)),
+            messageOnAuthenticationFailure = "Please re-authenticate",
             isPush = false,
             isEnabled = true,
             sizeThreshold = 0L
@@ -129,6 +134,7 @@ class GcpStorageServiceTest {
             projectId = PROJECT_ID,
             bucketName = BUCKET_NAME,
             gcpCredentials = ExportedKeyGcpCredentials(File(serviceAccountPath!!)),
+            messageOnAuthenticationFailure = "Please re-authenticate",
             isPush = true,
             isEnabled = false,
             sizeThreshold = 0L


### PR DESCRIPTION
Currently, Google Auth library caches default credentials indefinitely in a static field. This means if user's credentials expire, they run gcloud auth command, then try runnning Gradle again the old credentials are used. This change adds a reflection based mechanism to clear default credentials cache and retrying one additional time to get new credentials.

Additionally, allow specifying the message on authentication failure.