### PR TITLE
Add protection for 0 byte cache entries

### DIFF
--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpBuildCacheService.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpBuildCacheService.kt
@@ -64,6 +64,7 @@ internal class GcpBuildCacheService(
     }
 
     override fun store(key: BuildCacheKey, writer: BuildCacheEntryWriter) {
+        if (writer.size == 0L) return // do not store empty entries into the cache
         logger.info("Storing ${key.blobKey()}")
         val cacheKey = key.blobKey()
         val output = ByteArrayOutputStream()

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageService.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageService.kt
@@ -57,7 +57,6 @@ internal class GcpStorageService(
     }
 
     override fun store(cacheKey: String, contents: ByteArray): Boolean {
-
         if (!isEnabled) {
             logger.info("Not Enabled")
             return false
@@ -123,7 +122,10 @@ internal class GcpStorageService(
             if (storage == null) return null
             return try {
                 val blob = storage.service.get(blobId) ?: return null
-                return if (blob.size > sizeThreshold) {
+                return if (blob.size == 0L) {
+                    // return empty entries as a cache miss
+                    null
+                } else if (blob.size > sizeThreshold) {
                     val path = FileHandleInputStream.create()
                     blob.downloadTo(path)
                     path.handleInputStream()


### PR DESCRIPTION
In androidx we have observed that if Gradle OOMs it sometimes tries to write 0 byte cache entries which corrupt the remote cache for future builds. This change makes sure we do not write store/load such entries

Test: None