### PR TITLE
Better offline support in AWS implementation

### DIFF
--- a/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3BuildCacheService.kt
+++ b/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3BuildCacheService.kt
@@ -69,6 +69,7 @@ class S3BuildCacheService(
     }
 
     override fun store(key: BuildCacheKey, writer: BuildCacheEntryWriter) {
+        if (writer.size == 0L) return // do not store empty entries into the cache
         logger.info("Storing ${key.blobKey()}")
         val cacheKey = key.blobKey()
         val output = ByteArrayOutputStream()

--- a/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3StorageService.kt
+++ b/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3StorageService.kt
@@ -106,7 +106,7 @@ class S3StorageService(
                 throw Exception("Bucket $bucketName under project $region cannot be found or is not accessible using the provided credentials")
             }
         } catch (e: Exception) {
-            logger.warn("Couldn't validate S3 client config. This may be due to a connection error")
+            logger.warn("Couldn't validate S3 client config: ${e.message}")
         }
     }
 

--- a/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3StorageService.kt
+++ b/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3StorageService.kt
@@ -131,6 +131,7 @@ class S3StorageService(
             return try {
                 val inputStream = client.getObject(request)
                 val blob = inputStream.response() ?: return null
+                if (blob.contentLength() == 0L) return null // return empty entries as a cache miss
                 if (blob.contentLength() > sizeThreshold) {
                     val path = FileHandleInputStream.create()
                     val outputStream = path.outputStream()


### PR DESCRIPTION
We found that the S3 Amazon cline throws runtime exceptions when you attempt to instantiate it while your machine offline. This always happens at the entry point `validateConfiguration()`, so we're going to catch exceptions thrown there and warn about them. Also wraps the `delete()` operation in a try catch block