### PR TITLE
Allow using a specific AWS profile to auth

### DIFF
--- a/s3buildcache/README.md
+++ b/s3buildcache/README.md
@@ -27,7 +27,7 @@ buildCache {
 ```
 
 - `region`, `bucketName` are required.
-- `credentials` defaults to `DefaultS3Credentials`, but can also be set to `ExportedS3Credentials`, or `SpecificCredentialsProvider`.
+- `credentials` defaults to `DefaultS3Credentials`, but can also be set to `ExportedS3Credentials`, `ProfileS3Credentials`, or `SpecificCredentialsProvider`.
 - `isPush` defaults to `false`.
 
 ---

--- a/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3BuildCacheService.kt
+++ b/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3BuildCacheService.kt
@@ -24,10 +24,7 @@ import org.gradle.caching.BuildCacheEntryReader
 import org.gradle.caching.BuildCacheEntryWriter
 import org.gradle.caching.BuildCacheKey
 import org.gradle.caching.BuildCacheService
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.auth.credentials.*
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import java.io.ByteArrayOutputStream
@@ -103,6 +100,7 @@ class S3BuildCacheService(
             return when (s3Credentials) {
                 DefaultS3Credentials -> DefaultCredentialsProvider.create()
                 is SpecificCredentialsProvider -> s3Credentials.provider
+                is ProfileS3Credentials -> ProfileCredentialsProvider.create(s3Credentials.profile)
                 is ExportedS3Credentials -> StaticCredentialsProvider.create(
                     AwsBasicCredentials.create(s3Credentials.awsAccessKeyId, s3Credentials.awsSecretKey)
                 )

--- a/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3Credentials.kt
+++ b/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3Credentials.kt
@@ -28,7 +28,7 @@ sealed interface S3Credentials : Credentials
 /**
  * Use DefaultCredentialsProvider to authenticate to AWS.
  */
-object DefaultS3Credentials : S3Credentials
+data object DefaultS3Credentials : S3Credentials
 
 /**
  * Use a specific credentials provider
@@ -40,3 +40,8 @@ class SpecificCredentialsProvider(val provider: AwsCredentialsProvider) : S3Cred
  * Use provided keys to authenticate to AWS.
  */
 class ExportedS3Credentials(val awsAccessKeyId: String, val awsSecretKey: String) : S3Credentials
+
+/**
+ * Ensure that we load this profile to authenticate to AWS
+ */
+class ProfileS3Credentials(val profile: String) : S3Credentials


### PR DESCRIPTION
Technically, the plugin already allows you to do this by passing in an instance of `ProfileCredentialsProvider.create(s3Credentials.profile)` into `SpecificCredentialsProvider()`. The only annoying thing is to do this, you need to add the aws s3 sdk to your classpath in the settings script as such, and we didn't like that. Now I'm wondering if I should mark `SpecificCredentialsProvider` as deprecated, or leave it for anyone who wouldn't be bothered by this quirky behavior.


```
// settings.gradle(.kts)

buildscript {
    dependencies {
        classpath("aws-s3-dependency")
    }
}
```