### PR TITLE
Bump s3buildcache version

### DIFF
--- a/s3buildcache/README.md
+++ b/s3buildcache/README.md
@@ -8,7 +8,7 @@ In your `settings.gradle(.kts)` file add the following
 
 ```kotlin
 plugins {
-  id("androidx.build.gradle.s3buildcache") version "1.0.0-alpha04"
+  id("androidx.build.gradle.s3buildcache") version "1.0.0-alpha05"
 }
 
 import androidx.build.gradle.s3buildcache.S3BuildCache
@@ -36,7 +36,7 @@ If you are using Groovy, then you should do the following:
 
 ```groovy
 plugins {
-  id("androidx.build.gradle.s3buildcache") version "1.0.0-alpha04"
+  id("androidx.build.gradle.s3buildcache") version "1.0.0-alpha05"
 }
 
 import androidx.build.gradle.s3buildcache.ExportedS3Credentials

--- a/s3buildcache/build.gradle.kts
+++ b/s3buildcache/build.gradle.kts
@@ -61,7 +61,7 @@ gradlePlugin {
 }
 
 group = "androidx.build.gradle.s3buildcache"
-version = "1.0.0-alpha04"
+version = "1.0.0-alpha05"
 
 testing {
     suites {


### PR DESCRIPTION
Preparing for a release. It should include these changes: [[1](https://github.com/androidx/gcp-gradle-build-cache/pull/45)], [[2](https://github.com/androidx/gcp-gradle-build-cache/pull/44)], and [[3](https://github.com/androidx/gcp-gradle-build-cache/pull/43)]