### PR TITLE
Update GCP README

### DIFF
--- a/gcpbuildcache/README.md
+++ b/gcpbuildcache/README.md
@@ -7,16 +7,15 @@ An implementation of the Gradle Remote Cache that's backed by Google Cloud Stora
 In your `settings.gradle.kts` file add the following
 
 ```kotlin
-plugins {
-    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-beta07"
-}
-
 import androidx.build.gradle.gcpbuildcache.GcpBuildCache
 import androidx.build.gradle.gcpbuildcache.GcpBuildCacheServiceFactory
 import androidx.build.gradle.gcpbuildcache.ExportedKeyGcpCredentials
 
+plugins {
+    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-beta07"
+}
+
 buildCache {
-    registerBuildCacheService(GcpBuildCache::class, GcpBuildCacheServiceFactory::class)
     remote(GcpBuildCache::class) {
         projectId = "foo"
         bucketName = "bar"
@@ -44,7 +43,6 @@ import androidx.build.gradle.gcpbuildcache.GcpBuildCacheServiceFactory
 import androidx.build.gradle.gcpbuildcache.ExportedKeyGcpCredentials
 
 buildCache {
-    registerBuildCacheService(GcpBuildCache, GcpBuildCacheServiceFactory)
     remote(GcpBuildCache) {
         projectId = "projectName"
         bucketName = "storageBucketName"


### PR DESCRIPTION
- move imports to top of file
- remove unnecessary registerBuildCacheService, it's added by the GCP Settings plugin

   https://github.com/androidx/gcp-gradle-build-cache/blob/6ff65738c57f787299fbcba2051b831cfc4b5bac/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpGradleBuildCachePlugin.kt#L28-L31