### PR TITLE
Update signing `onlyIf {}` check to be CC compatible

### DIFF
--- a/gcpbuildcache/build.gradle.kts
+++ b/gcpbuildcache/build.gradle.kts
@@ -89,5 +89,6 @@ tasks.named<Task>("check") {
 }
 
 tasks.withType<Sign>().configureEach {
-    onlyIf { project.hasProperty("signing.keyId") }
+    val signingKeyIdPresent = project.hasProperty("signing.keyId")
+    onlyIf("signing.keyId is present") { signingKeyIdPresent }
 }

--- a/s3buildcache/build.gradle.kts
+++ b/s3buildcache/build.gradle.kts
@@ -98,5 +98,6 @@ tasks.named<Task>("check") {
 }
 
 tasks.withType<Sign>().configureEach {
-    onlyIf { project.hasProperty("signing.keyId") }
+    val signingKeyIdPresent = project.hasProperty("signing.keyId")
+    onlyIf("signing.keyId is present") { signingKeyIdPresent }
 }


### PR DESCRIPTION
Currently the `onlyIf {}` check is not compatible with CC, because [it uses Project at runtime](https://docs.gradle.org/8.6/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution).

This PR fixes this by redefining the value as a local val, allowing it to be cached by Grade.

Additionally, I added a message to the `onlyIf {}` check.