### PR TITLE
support for s3 express one zone as cache

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 gradle-publish = "1.1.0"
 kotlin = "1.9.22"
-amazon-bom = "2.20.18"
+amazon-bom = "2.25.0"
 google-cloud-storage = "2.30.1"
 s3-mock = "2.11.0"
 retrofit = "2.9.0"

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1,232 +1,1453 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2022 The Android Open Source Project
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~
-  -->
 <verification-metadata xmlns="https://schema.gradle.org/dependency-verification" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.3.xsd">
    <configuration>
       <verify-metadata>true</verify-metadata>
-      <verify-signatures>true</verify-signatures>
-      <keyring-format>armored</keyring-format>
-      <key-servers enabled="false">
-         <key-server uri="https://keyserver.ubuntu.com"/>
-         <key-server uri="https://keys.openpgp.org"/>
-      </key-servers>
-      <trusted-artifacts>
-         <trust group="gradle" name="gradle"/>
-         <trust group="org.codehaus.groovy"/>
-      </trusted-artifacts>
-      <ignored-keys>
-         <ignored-key id="D433B437192A0FD1" reason="Key is not available in any key server"/>
-      </ignored-keys>
-      <trusted-keys>
-         <trusted-key id="04543577D6A9CC626239C50C7ECBD740FF06AEB5">
-            <trusting group="com.sun.istack"/>
-            <trusting group="com.sun.xml.bind"/>
-            <trusting group="com.sun.xml.bind.mvn"/>
-            <trusting group="org.glassfish.jaxb"/>
-         </trusted-key>
-         <trusted-key id="0785B3EFF60B1B1BEA94E0BB7C25280EAE63EBE5" group="org.apache.httpcomponents"/>
-         <trusted-key id="07E20F0103D9DFC697C490D0368557390486F2C5" group="io.rest-assured"/>
-         <trusted-key id="0B743A794876D3C78AB542A118D239B1CBCD2236" group="org.glassfish.jersey"/>
-         <trusted-key id="0CC641C3A62453AB390066C4A41F13C999945293" group="commons-logging"/>
-         <trusted-key id="0D35D3F60078655126908E8AF3D1600878E85A3D" group="io.netty"/>
-         <trusted-key id="0F07D1201BDDAB67CFB84EB479752DB6C966F0B8" group="com.google.android"/>
-         <trusted-key id="120D6F34E627ED3A772EBBFE55C7E5E701832382" group="org.yaml"/>
-         <trusted-key id="147B691A19097624902F4EA9689CBE64F4BC997F" group="org.mockito"/>
-         <trusted-key id="1597AB231B7ADD7E14B1D9C43F00DB67AE236E2E" group="org.conscrypt"/>
-         <trusted-key id="19BEAB2D799C020F17C69126B16698A4ADF4D638" group="org.checkerframework"/>
-         <trusted-key id="1A55F091AD28C07F831FA44D7905DE25C78AD456" group="com.google.protobuf"/>
-         <trusted-key id="1FA37FBE4453C1073E7EF61D6449005F96BC97A3" group="de.undercouch"/>
-         <trusted-key id="2518174F4111F02779592A6F9757D7E7E06DD2AC" group="io.prometheus"/>
-         <trusted-key id="28118C070CB22A0175A2E8D43D12CA2AC19F3181">
-            <trusting group="com.fasterxml"/>
-            <trusting group="com.fasterxml.jackson"/>
-            <trusting group="com.fasterxml.jackson.core"/>
-            <trusting group="com.fasterxml.jackson.dataformat"/>
-            <trusting group="com.fasterxml.jackson.datatype"/>
-            <trusting group="com.fasterxml.jackson.module"/>
-            <trusting group="com.fasterxml.woodstox"/>
-            <trusting group="jakarta.annotation"/>
-         </trusted-key>
-         <trusted-key id="2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB">
-            <trusting group="commons-codec"/>
-            <trusting group="commons-io"/>
-            <trusting group="org.apache.commons"/>
-         </trusted-key>
-         <trusted-key id="2E3A1AFFE42B5F53AF19F780BCF4173966770193" group="org.jetbrains"/>
-         <trusted-key id="2E5B73C6EFD2EB453104C2EAE6EC76B4C6D3AE8E" group="com.google.protobuf"/>
-         <trusted-key id="2EABB8F15F15E18885312232372703E4D5313120" group="org.glassfish.jersey"/>
-         <trusted-key id="314FE82E5A4C5377BCA2EDEC5208812E1E4A6DB0" group="com.gradle.publish"/>
-         <trusted-key id="44FBDBBC1A00FE414F1C1873586654072EAD6677" group="org.sonatype.oss"/>
-         <trusted-key id="46FE5498DCCEA1A9C7D29F8B1F9CF1652EE7899D" group="com.adobe.testing"/>
-         <trusted-key id="47504B76CF89C15C0512D9AFE16AB52D79FD224F">
-            <trusting group="com.google.api"/>
-            <trusting group="com.google.api-client"/>
-            <trusting group="com.google.api.grpc"/>
-            <trusting group="com.google.apis"/>
-            <trusting group="com.google.auth"/>
-            <trusting group="com.google.cloud"/>
-            <trusting group="com.google.http-client"/>
-            <trusting group="com.google.oauth-client"/>
-         </trusted-key>
-         <trusted-key id="475F3B8E59E6E63AA78067482C7B12F2A511E325">
-            <trusting group="ch.qos.logback"/>
-            <trusting group="org.slf4j"/>
-         </trusted-key>
-         <trusted-key id="48F8E69F6390C9F25CFEDCD268248959359E722B" group="org.apache.tomcat.embed"/>
-         <trusted-key id="4DB1A49729B053CAF015CEE9A6ADFC93EF34893E" group="org.hamcrest"/>
-         <trusted-key id="4F7E32D440EF90A83011A8FC6425559C47CC79C4" group="javax.annotation"/>
-         <trusted-key id="53C935821AA6A755BD337DB53595395EB3D8E1BA" group="org.apache.logging.log4j"/>
-         <trusted-key id="54A26BFDC7ECDD39BA4C123AC3BAB45F4AF71FAB" group="io.opencensus"/>
-         <trusted-key id="55C895C9A9A107F87E6E3BDC3C9B410084525C69" group="io.prometheus"/>
-         <trusted-key id="55E770230E69CC6DE143FB5B62C82E50836EB3EE" group="com.github.gundy"/>
-         <trusted-key id="57312C37B064EE0FDAB0130490D5CE79E1DE6A2C" group="com.querydsl"/>
-         <trusted-key id="59A8E169739301FD48139CA00E325BECB6962A24" group="jakarta.annotation"/>
-         <trusted-key id="600EA202B1EC682F4A788E5AAC7A514BC9F9BB70" group="io.opencensus"/>
-         <trusted-key id="6214760097DC5CFAD0175AC2C9FBAA83A8753994">
-            <trusting group="com.fasterxml"/>
-            <trusting group="org.codehaus.woodstox"/>
-         </trusted-key>
-         <trusted-key id="6847BFA6411965A23F08C6366A97BB242496B68A" group="com.google.re2j"/>
-         <trusted-key id="694621A7227D8D5289699830ABE9F3126BB741C1" group="com.google.guava"/>
-         <trusted-key id="6DD3B8C64EF75253BEB2C53AD908A43FB7EC07AC" group="com.sun.activation"/>
-         <trusted-key id="6F538074CCEBF35F28AF9B066A0975F8B1127B83">
-            <trusting group="org.jetbrains.kotlin"/>
-            <trusting group="org.jetbrains.kotlin.jvm"/>
-         </trusted-key>
-         <trusted-key id="7464550A61C90BA385FC97A76D9567281201E5E3" group="jakarta.servlet"/>
-         <trusted-key id="748F15B2CF9BA8F024155E6ED7C92B70FA1C814D" group="org.apache.logging"/>
-         <trusted-key id="7615AD56144DF2376F49D98B1669C4BB543E0445" group="com.google.errorprone"/>
-         <trusted-key id="7616EB882DAF57A11477AAF559A252FB1199D873" group="com.google.code.findbugs"/>
-         <trusted-key id="798E2DA37E70DAE0EA9E498CA388C395AAFB80F8" group="io.dropwizard.metrics"/>
-         <trusted-key id="7A1D848E7C2AF85EEBA69C99E7BF252CF360097E" group="org.latencyutils"/>
-         <trusted-key id="7E22D50A7EBD9D2CD269B2D4056ACA74D46000BF" group="io.netty"/>
-         <trusted-key id="84789D24DF77A32433CE1F079EB80E92EB2135B1">
-            <trusting group="org.apache"/>
-            <trusting group="org.codehaus.mojo"/>
-         </trusted-key>
-         <trusted-key id="8756C4F765C9AC3CB6B85D62379CE192D401AB61" group="org.jetbrains.intellij.deps"/>
-         <trusted-key id="8A10792983023D5D14C93B488D7F1BEC1E2ECAE7">
-            <trusting group="com.fasterxml"/>
-            <trusting group="com.fasterxml.jackson"/>
-            <trusting group="com.fasterxml.jackson.core"/>
-         </trusted-key>
-         <trusted-key id="90EE19787A7BCF6FD37A1E9180C08B1C29100955" group="com.squareup.retrofit2"/>
-         <trusted-key id="9B32CBC0F3F6BA4C13D611FC21871D2A9AB66A31" group="io.rsocket"/>
-         <trusted-key id="9D0A56AAA0D60E0C0C7DCCC0B4C70893B62BABE8" group="org.apache.logging"/>
-         <trusted-key id="A33A0B49A4C1AB590B0A4DDC1364C5E2DF3E99C5" group="org.reactivestreams"/>
-         <trusted-key id="A6D6C97108B8585F91B158748671A8DF71296252">
-            <trusting group="com.squareup.okhttp3"/>
-            <trusting group="com.squareup.okio"/>
-         </trusted-key>
-         <trusted-key id="AA70C7C433D501636392EC02153E7A3C2B4E5118" group="org.eclipse.ee4j"/>
-         <trusted-key id="AFCC4C7594D09E2182C60E0F7A01B0F236E5430F" group="com.google.code.gson"/>
-         <trusted-key id="AFEDF1B56323F5291EC3ED2E260E672C0D78E9B0" group="jakarta.servlet"/>
-         <trusted-key id="B02137D875D833D9B23392ECAE5A7FB608A0221C" group="org.apache.maven"/>
-         <trusted-key id="B02335AA54CCF21E52BBF9ABD9C565AA72BA2FDD" group="io.grpc"/>
-         <trusted-key id="B41089A2DA79B0FA5810252872385FF0AF338D52" group="org.threeten"/>
-         <trusted-key id="B801E2F8EF035068EC1139CC29579F18FA8FD93B" group="com.google.j2objc"/>
-         <trusted-key id="BC87A3FD0A54480F0BADBEBD21939FF0CA2A6567" group="commons-codec"/>
-         <trusted-key id="BDB5FA4FE719D787FB3D3197F6D4A1D411E9D1AE" group="com.google.guava"/>
-         <trusted-key id="C6F7D1C804C821F49AF3BFC13AD93C3C677A106E" group="io.perfmark"/>
-         <trusted-key id="C7BE5BCC9FEC15518CFDA882B0F3710FA64900E7">
-            <trusting group="com.google.auto"/>
-            <trusting group="com.google.auto.value"/>
-            <trusting group="com.google.code.gson"/>
-         </trusted-key>
-         <trusted-key id="D022218DCC08AAD6EF3AF876B3DE72E647D35161" group="org.testcontainers"/>
-         <trusted-key id="D33620F0D0864EC924483F6F3FF95B4331B1F3B7" group="org.testcontainers"/>
-         <trusted-key id="D4C89EA4AAF455FD88B22087EFE8086F9E93774E" group="junit"/>
-         <trusted-key id="DBD744ACE7ADE6AA50DD591F66B50994442D2D40" group="^com[.]squareup($|([.].*))" regex="true"/>
-         <trusted-key id="E113159331A1F87BFC2A93D0960D2E8635A91268" group="org.hdrhistogram"/>
-         <trusted-key id="E2ACB037933CDEAAB7BF77D49A2C7A98E457C53D">
-            <trusting group="io.micrometer"/>
-            <trusting group="io.projectreactor"/>
-            <trusting group="org.springframework"/>
-            <trusting group="org.springframework.boot"/>
-            <trusting group="org.springframework.data"/>
-            <trusting group="org.springframework.integration"/>
-            <trusting group="org.springframework.security"/>
-            <trusting group="org.springframework.session"/>
-         </trusted-key>
-         <trusted-key id="E7DC75FC24FB3C8DFE8086AD3D5839A2262CBBFB" group="org.jetbrains.kotlinx"/>
-         <trusted-key id="E82D2EAF2E83830CE1F7F6BE571A5291E827E1C7" group="net.java"/>
-         <trusted-key id="EB1B3DE71713C9EC2E87CC26EE92349AD86DE446" group="com.google.j2objc"/>
-         <trusted-key id="EDA86E9FB607B5FC9223FB767D4868B53E31E7AD" group="io.dropwizard.metrics"/>
-         <trusted-key id="EE0CA873074092F806F59B65D364ABAA39A47320" group="com.google.errorprone"/>
-         <trusted-key id="EF6AD6684034B0CB67A9B5714406B84C1661DCD1">
-            <trusting group="io.r2dbc"/>
-            <trusting group="org.springframework.data"/>
-         </trusted-key>
-         <trusted-key id="F1A51E051F527E0C8E24D54D4B1E11D5A4B91E89" group="com.google.protobuf"/>
-         <trusted-key id="F254B35617DC255D9344BCFA873A8E86B4372146" group="org.eclipse.jetty"/>
-         <trusted-key id="F5FEBA84EB26C56457B2CF819E31AB27445478DB" group="org.infinispan"/>
-         <trusted-key id="F674EBA7B6EC777BDB58942DE0E92C40A43A012A" group="jakarta.websocket"/>
-         <trusted-key id="F6CE460FDBE1AABD1A96456737ECFC571637667C" group="jakarta.annotation"/>
-         <trusted-key id="FA77DCFEF2EE6EB2DEBEDD2C012579464D01C06A">
-            <trusting group="org.apache"/>
-            <trusting group="org.apache.maven"/>
-         </trusted-key>
-         <trusted-key id="FA7929F83AD44C4590F6CC6815C71C0A4E0B8EDD" group="net.java.dev.jna"/>
-         <trusted-key id="FC411CD3CB7DCB0ABC9801058118B3BCDB1A5000" group="jakarta.xml.bind"/>
-         <trusted-key id="FE72F1BFE9632B1FE049AC3E5BCD80B78ACD3A37" group="com.oracle.database.jdbc"/>
-         <trusted-key id="FEB9209F2F2F3F4664841E55AC107B386692DADD" group="^software[.]amazon($|([.].*))" regex="true"/>
-         <trusted-key id="FF6E2C001948C5F2F38B0CC385911F425EC61B51">
-            <trusting group="junit"/>
-            <trusting group="org.apiguardian"/>
-            <trusting group="org.junit"/>
-            <trusting group="org.junit.jupiter"/>
-            <trusting group="org.junit.platform"/>
-            <trusting group="org.opentest4j"/>
-         </trusted-key>
-         <trusted-key id="FFA95B1DD22FE6D191189AFA718E28A09E67016B" group="jakarta.websocket"/>
-      </trusted-keys>
+      <verify-signatures>false</verify-signatures>
    </configuration>
    <components>
+      <component group="com.adobe.testing" name="s3mock" version="2.11.0">
+         <artifact name="s3mock-2.11.0.jar">
+            <sha256 value="3a8a69a3dc2feb50824a9c4eacaaee3c6cf47915440ceec4a7bb96f8b0ecd223" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="s3mock-2.11.0.pom">
+            <sha256 value="8358d738fd344d68d3dd9d232ae72d58c48f86060544d7b81a98475e83bca0a1" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.adobe.testing" name="s3mock-parent" version="2.11.0">
+         <artifact name="s3mock-parent-2.11.0.pom">
+            <sha256 value="e2e09e647f727dd6346b4f3b9ad018288f6e7415bd9dae4a4e2e0b52171b9836" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
       <component group="com.datastax.oss" name="java-driver-bom" version="4.14.1">
          <artifact name="java-driver-bom-4.14.1.pom">
-            <sha256 value="73046e3a868d402ea1316d739f498dd859a504b809ac8fa9ff238e5758202728" origin="Generated by Gradle" reason="A key couldn't be downloaded"/>
+            <sha256 value="73046e3a868d402ea1316d739f498dd859a504b809ac8fa9ff238e5758202728" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml" name="oss-parent" version="38">
+         <artifact name="oss-parent-38.pom">
+            <sha256 value="c83f8f45dfdca8d0b6b3661c60b3f84780f671b12e06f91ad5d1c1a1d1f966e8" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml" name="oss-parent" version="43">
+         <artifact name="oss-parent-43.pom">
+            <sha256 value="e5585cc1c37079b2e3817a8997945736f158831844d59d0e4d3a45b27611f926" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml" name="oss-parent" version="45">
+         <artifact name="oss-parent-45.pom">
+            <sha256 value="f005ec0ae37ad94a0d060d8ba3b79e6659510fbb5ea5e464c358d91c33c3c17b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml" name="oss-parent" version="56">
+         <artifact name="oss-parent-56.pom">
+            <sha256 value="fd491f78857424106d2e3d605bcd799b53d31a565cdc868463ca7e875db45a50" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson" name="jackson-base" version="2.16.0">
+         <artifact name="jackson-base-2.16.0.pom">
+            <sha256 value="f9b7476ec3798a125f14c9da546fa7af861ead93a1999b2c0d363b9592c2336e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson" name="jackson-bom" version="2.13.4">
+         <artifact name="jackson-bom-2.13.4.pom">
+            <sha256 value="435e9493ddaa96e51995be83b31376ebffd2b37361d8567e1ea14e1c64c3f0d7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson" name="jackson-bom" version="2.13.4.20221013">
+         <artifact name="jackson-bom-2.13.4.20221013.pom">
+            <sha256 value="cb63f8ff98c7ccbe531e3764be2c91d275b8fcfe2972cd67aa7f0a781a239a36" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson" name="jackson-bom" version="2.16.0">
+         <artifact name="jackson-bom-2.16.0.pom">
+            <sha256 value="5aaa28874405bf04fba8e2c57159227824461ba6f7d552abdb8e8d3a0ba6f8bf" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson" name="jackson-parent" version="2.13">
+         <artifact name="jackson-parent-2.13.pom">
+            <sha256 value="2bba89978172af1effcb4d143d09921a3f3082ca4dcf122b1ded98bf55b2ad57" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson" name="jackson-parent" version="2.16">
+         <artifact name="jackson-parent-2.16.pom">
+            <sha256 value="8bf6142812148a2abf6850b272f0af4c3d8ff1121ed604c402f3f38c9e6546ab" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson.core" name="jackson-annotations" version="2.13.4">
+         <artifact name="jackson-annotations-2.13.4.jar">
+            <sha256 value="ac5b27a634942391ca113850ee7db01df1499a240174021263501c05fc653b44" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jackson-annotations-2.13.4.module">
+            <sha256 value="649d6a2770182c6361ed8e2d6ea546e5f7123ef7a62fe7fad135d43184156d8f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson.core" name="jackson-core" version="2.13.4">
+         <artifact name="jackson-core-2.13.4.jar">
+            <sha256 value="4c2e043200edd9ee7ba6fc378bd5c17784a5bf2388e152d208068b51fd0839cf" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jackson-core-2.13.4.module">
+            <sha256 value="7b2d5efa46a913848ea9a7c12a5a5c1e112e610499c9a17299d42092e35b67f0" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson.core" name="jackson-core" version="2.16.0">
+         <artifact name="jackson-core-2.16.0.jar">
+            <sha256 value="66e2cde4cc7e565d5fce2a2998b64e991777bf9fad4d220735c525fd8d01c31a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jackson-core-2.16.0.module">
+            <sha256 value="7edc76ca2e29445ef2abe0111c5d67435c934f8fbaad217570734cf253352d2c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson.core" name="jackson-databind" version="2.13.4">
+         <artifact name="jackson-databind-2.13.4.module">
+            <sha256 value="692c31f4406d175d06c59d96e8b1665f7bd5cec1cb54e6a35cacace547808278" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson.core" name="jackson-databind" version="2.13.4.2">
+         <artifact name="jackson-databind-2.13.4.2.jar">
+            <sha256 value="ba1a368137f9b92f48dd07f299ff7a782a69487b853ef5578215426fcde8f08b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jackson-databind-2.13.4.2.module">
+            <sha256 value="e2dc82b1049c7bbf96ec56302cfbf381dd5114c793e0f9bf4bb3c4821fedd7f3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson.dataformat" name="jackson-dataformat-xml" version="2.13.4">
+         <artifact name="jackson-dataformat-xml-2.13.4.jar">
+            <sha256 value="76fbf0cedd51af6a13aba39c27c8c29a5a280dc24ee66577d559e4660d8709ce" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jackson-dataformat-xml-2.13.4.module">
+            <sha256 value="4ac66c9b062e51e8b7503980b4a68cda6ec25dd4740f7f7b497335b7917b7f31" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson.datatype" name="jackson-datatype-jdk8" version="2.13.4">
+         <artifact name="jackson-datatype-jdk8-2.13.4.jar">
+            <sha256 value="fc568852020844d753d12d93c5ac25ef545792ac4926b3075e81c42ac32e606e" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jackson-datatype-jdk8-2.13.4.module">
+            <sha256 value="8c54cf9f1b78abe28537cdaf7654306cc95a69f26711b48711e6ee336c36d78e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson.datatype" name="jackson-datatype-jsr310" version="2.13.4">
+         <artifact name="jackson-datatype-jsr310-2.13.4.jar">
+            <sha256 value="5ad75d210bacc17271925da28e1f393aaf8c83f6c92fbe5b2ed61954b84decf7" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jackson-datatype-jsr310-2.13.4.module">
+            <sha256 value="a97f0e8559b5018174055c1d926fb7dbe27f31704272c737a9f85c35127b183f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.jackson.module" name="jackson-module-parameter-names" version="2.13.4">
+         <artifact name="jackson-module-parameter-names-2.13.4.jar">
+            <sha256 value="e67856b02a988768784c5a675c0ad5c17e330cd78375ef39e740cbf04879d363" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jackson-module-parameter-names-2.13.4.module">
+            <sha256 value="aed7c6bc6bb7d04e30677afd77c16ee97337cb03b7261e2040fa6b24bd26ebe4" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.fasterxml.woodstox" name="woodstox-core" version="6.3.1">
+         <artifact name="woodstox-core-6.3.1.jar">
+            <sha256 value="8b39cb6f28d3f946fbc0a2563dcca550a597471e162d60a3fa228132498d1584" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="woodstox-core-6.3.1.pom">
+            <sha256 value="42516bd05829b35396b873f3f89b82b3eaf87080576c5e99bb6e254d37e1f065" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.android" name="annotations" version="4.1.1.4">
+         <artifact name="annotations-4.1.1.4.jar">
+            <sha256 value="ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="annotations-4.1.1.4.pom">
+            <sha256 value="e4bb54753c36a27a0e5d70154a5034fedd8feac4282295034bfd483d6c7aae78" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api" name="api-common" version="2.21.0">
+         <artifact name="api-common-2.21.0.jar">
+            <sha256 value="47572feebdae0af7fb4d2d9c65dae1bbbd6b54d972895d3ff0d77b18c41a8530" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="api-common-2.21.0.pom">
+            <sha256 value="7e50d4d23d013f19ee5c450146a87b007bd0ec90195173a664b30407d98ee331" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api" name="gapic-generator-java-bom" version="2.30.0">
+         <artifact name="gapic-generator-java-bom-2.30.0.pom">
+            <sha256 value="84d31f1dff9439be7a6bb3a588e9893775079ffc1d26b9e37e2892ffe2ed50b4" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api" name="gapic-generator-java-pom-parent" version="2.30.0">
+         <artifact name="gapic-generator-java-pom-parent-2.30.0.pom">
+            <sha256 value="074ec6f11d0a86119556754492d4e0e7bc407e2e94030ed756a2b8c8166fcb01" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api" name="gax" version="2.38.0">
+         <artifact name="gax-2.38.0.jar">
+            <sha256 value="2ab7617e180f3f980ade040656004df124f5f0939b96de98e6316a44ca27a17b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="gax-2.38.0.pom">
+            <sha256 value="75ada8dff0de957c7ce51294119fc1733ce8eef9873d62719415edcf12cd0f1f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api" name="gax-bom" version="2.38.0">
+         <artifact name="gax-bom-2.38.0.pom">
+            <sha256 value="b2a48d91ea4434c0f2029d6c3c5734820c55af2245e52382edf9200ebfc08bf6" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api" name="gax-grpc" version="2.38.0">
+         <artifact name="gax-grpc-2.38.0.jar">
+            <sha256 value="6c5e6a3c6d2473826d29cb48c0e131afa7819d13a9779b920afeab1bb9950369" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="gax-grpc-2.38.0.pom">
+            <sha256 value="acbe3046c3f44d0aadd6db9ccd8c35cc60d5ec65f5ef692487330aa49d83f2af" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api" name="gax-httpjson" version="2.38.0">
+         <artifact name="gax-httpjson-2.38.0.jar">
+            <sha256 value="4917fc91fd5726e0c88ddb52325bf20564b30f01b2578865807ada2100b59534" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="gax-httpjson-2.38.0.pom">
+            <sha256 value="f1b48db845f503271a0c58e9302e80ffe11020a682e57323519e19664ac67636" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api" name="gax-parent" version="2.38.0">
+         <artifact name="gax-parent-2.38.0.pom">
+            <sha256 value="5350edc5cbdde4c1adb1ced85162d7f921134a71bfcc24d242a6efd61a6a4e92" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api-client" name="google-api-client" version="2.2.0">
+         <artifact name="google-api-client-2.2.0.jar">
+            <sha256 value="58eca9fb0a869391689ffc828b3bd0b19ac76042ff9fab4881eddf7fde76903f" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-api-client-2.2.0.pom">
+            <sha256 value="4d17f933b9b659fd0902dba7f820e1be672c0b52153634a950cc1ffbb5d223fc" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api-client" name="google-api-client-bom" version="2.2.0">
+         <artifact name="google-api-client-bom-2.2.0.pom">
+            <sha256 value="f11b6064e6487fa4c8ed3101397b079d76c6ad0079af6fa70e3a0582505f058b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api-client" name="google-api-client-parent" version="2.2.0">
+         <artifact name="google-api-client-parent-2.2.0.pom">
+            <sha256 value="90e62df83eaad81d4f5bac8af11179c0aaedb203bcc6488a29a0f75d771ca2ff" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api.grpc" name="gapic-google-cloud-storage-v2" version="2.30.1-alpha">
+         <artifact name="gapic-google-cloud-storage-v2-2.30.1-alpha.jar">
+            <sha256 value="abbaedff6802ca341bcc659d06ff576d99a7770208f37b8bd2c425e071648769" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="gapic-google-cloud-storage-v2-2.30.1-alpha.pom">
+            <sha256 value="f623c0e50cf33785a8f4333f51cc3565c1195b591fb5e4543938978a4fba6a4b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api.grpc" name="grpc-google-cloud-storage-v2" version="2.30.1-alpha">
+         <artifact name="grpc-google-cloud-storage-v2-2.30.1-alpha.jar">
+            <sha256 value="ab7401c35f7225bd801d61d710f0af774cf73b92ef0d52fed13957e0da1ed27b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-google-cloud-storage-v2-2.30.1-alpha.pom">
+            <sha256 value="00fd24cf6d8613038526d3c421b44ce7bad32ba275dfe3db09c53f349fdcb2dc" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api.grpc" name="proto-google-cloud-storage-v2" version="2.30.1-alpha">
+         <artifact name="proto-google-cloud-storage-v2-2.30.1-alpha.jar">
+            <sha256 value="7d6c03c20a560923e036600efe139738ffb0ece4f8eedf76c70c2aa38434eb21" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="proto-google-cloud-storage-v2-2.30.1-alpha.pom">
+            <sha256 value="6be9bd42f82bb18664f40a0d64a591c57e28db7e9a2665f8edc8449781261536" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api.grpc" name="proto-google-common-protos" version="2.29.0">
+         <artifact name="proto-google-common-protos-2.29.0.jar">
+            <sha256 value="ee9c751f06b112e92b37f75e4f73a17d03ef2c3302c6e8d986adbcc721b63cb0" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="proto-google-common-protos-2.29.0.pom">
+            <sha256 value="6ee1ea16588ecec9fbf412d7ad1ba557bc456ce097520dee5e4cd08ae61c2784" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.api.grpc" name="proto-google-iam-v1" version="1.24.0">
+         <artifact name="proto-google-iam-v1-1.24.0.jar">
+            <sha256 value="4273279bc51a3c837d6a52c64f90e0beda7994a7ff86f4033c55786d8dd6f307" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="proto-google-iam-v1-1.24.0.pom">
+            <sha256 value="1340c44c8532a5e9c3b9a3860bebbaa97855c7293af2b743d8260d316a974ea9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.apis" name="google-api-services-storage" version="v1-rev20231117-2.0.0">
+         <artifact name="google-api-services-storage-v1-rev20231117-2.0.0.jar">
+            <sha256 value="b60b27ea9eb25e16d36d13bc337ef048aa0719a93e162cdb4cfb686ae5a975bd" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-api-services-storage-v1-rev20231117-2.0.0.pom">
+            <sha256 value="110204ea26450f1136d2ca5cf713666237e88cfeb8bc9a61df3f38d3f8740c9b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.auth" name="google-auth-library-bom" version="1.20.0">
+         <artifact name="google-auth-library-bom-1.20.0.pom">
+            <sha256 value="527e857509004af28a42b3899388790d5c9cd069d8a3d87f443ae8b0c89d50ca" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.auth" name="google-auth-library-credentials" version="1.20.0">
+         <artifact name="google-auth-library-credentials-1.20.0.jar">
+            <sha256 value="b3054d8757807f8af8015b535fb288ed67456444922211f0f929f4c04e69b0b7" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-auth-library-credentials-1.20.0.pom">
+            <sha256 value="23156951a34fab499d05f1b5d4cc5a1f58df40842c8a9192413974ebb2faae32" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.auth" name="google-auth-library-oauth2-http" version="1.20.0">
+         <artifact name="google-auth-library-oauth2-http-1.20.0.jar">
+            <sha256 value="ab3ee74eeccb12fca40f4444af4d45df9e290f2c3f4751e855697dedf52f7a73" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-auth-library-oauth2-http-1.20.0.pom">
+            <sha256 value="0538908c5889f0d403922403737e8a4113bff06aabcbddae17be7a41a650a40a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.auth" name="google-auth-library-parent" version="1.20.0">
+         <artifact name="google-auth-library-parent-1.20.0.pom">
+            <sha256 value="50063dc937b457a0151ddd9de9558de8b99298c909e1becf209a63eefca70da7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.auto.value" name="auto-value-annotations" version="1.10.4">
+         <artifact name="auto-value-annotations-1.10.4.jar">
+            <sha256 value="e1c45e6beadaef9797cb0d9afd5a45621ad061cd8632012f85582853a3887825" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="auto-value-annotations-1.10.4.pom">
+            <sha256 value="73a5b8515f85f88c4089f7ff4a43cd1795a481fdab93fa9050b13cfa1a8d25f7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.auto.value" name="auto-value-parent" version="1.10.4">
+         <artifact name="auto-value-parent-1.10.4.pom">
+            <sha256 value="bec3a19e4ddc8b6406672333cc505b9e0cb6b3558bb242314869bb6e1d688d30" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="first-party-dependencies" version="3.20.0">
+         <artifact name="first-party-dependencies-3.20.0.pom">
+            <sha256 value="4345ae7c7820facc5e209663331bf785d0951dfb4c8d4ca0865815d034af634b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="google-cloud-core" version="2.28.0">
+         <artifact name="google-cloud-core-2.28.0.jar">
+            <sha256 value="51f1fadc400273d9b4efdd1a285be628929fc61184f2d6471f20dc1580bea765" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-cloud-core-2.28.0.pom">
+            <sha256 value="20711cc47f3a48f6f5cabd9ebe7eae3bef5dd457f3b1086cb1006567f77079da" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="google-cloud-core-bom" version="2.28.0">
+         <artifact name="google-cloud-core-bom-2.28.0.pom">
+            <sha256 value="883d1d04d5f3f85f4581a17e3a2bfea19c1126b47102c14a82c043b219136bef" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="google-cloud-core-grpc" version="2.28.0">
+         <artifact name="google-cloud-core-grpc-2.28.0.jar">
+            <sha256 value="eb35fdf8f123f9aec03123e15baac0cf57a95e11f8c7673ba849db6f41264896" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-cloud-core-grpc-2.28.0.pom">
+            <sha256 value="909ed81496b70fda24cc5fe68eaf70fb7c3998dc7618731bfbcad9720a27335a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="google-cloud-core-http" version="2.28.0">
+         <artifact name="google-cloud-core-http-2.28.0.jar">
+            <sha256 value="24fb818e9ed1f4ee6af669dd7651cd2ac270426e8423b6e449b6cb3ee1e09f77" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-cloud-core-http-2.28.0.pom">
+            <sha256 value="3f594a511d809de433e7cd8953f9c3cbdf0f782a1cfec3d53b0fc772fd40cd62" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="google-cloud-core-parent" version="2.28.0">
+         <artifact name="google-cloud-core-parent-2.28.0.pom">
+            <sha256 value="7ca64656a62d1fd1a767f1ee88ff5572e4522c62ffabbe181ec0a99536fb71b1" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="google-cloud-shared-config" version="1.6.1">
+         <artifact name="google-cloud-shared-config-1.6.1.pom">
+            <sha256 value="7fbb48363575dc0bc36fd0560461cb18f9c3bad446d7e8e51e2148b8ea856b1d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="google-cloud-shared-dependencies" version="3.20.0">
+         <artifact name="google-cloud-shared-dependencies-3.20.0.pom">
+            <sha256 value="f0da6f6742ef6491a75eacb9a54256017f4f940e2d7972a8cd38d3e3a0386b60" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="google-cloud-storage" version="2.30.1">
+         <artifact name="google-cloud-storage-2.30.1.jar">
+            <sha256 value="1d787329926d8a430f24180afb346578cab42477392930843b7266e757a55c4d" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-cloud-storage-2.30.1.pom">
+            <sha256 value="0fd15fbc099056e1e5ce4f4122a870580fb6cf6282e33f8832b72920bcab9f17" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="google-cloud-storage-parent" version="2.30.1">
+         <artifact name="google-cloud-storage-parent-2.30.1.pom">
+            <sha256 value="60c3e6dd7814669c74066cabb7351f701399606ab1106e93577063707ffaf8df" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.cloud" name="third-party-dependencies" version="3.20.0">
+         <artifact name="third-party-dependencies-3.20.0.pom">
+            <sha256 value="0f22c433ca527238ee9dcefa987f80b3913675a7a10bcbd3aff261c55a567120" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.code.findbugs" name="jsr305" version="3.0.2">
+         <artifact name="jsr305-3.0.2.jar">
+            <sha256 value="766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jsr305-3.0.2.pom">
+            <sha256 value="19889dbdf1b254b2601a5ee645b8147a974644882297684c798afe5d63d78dfe" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.code.gson" name="gson" version="2.10.1">
+         <artifact name="gson-2.10.1.jar">
+            <sha256 value="4241c14a7727c34feea6507ec801318a3d4a90f070e4525681079fb94ee4c593" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="gson-2.10.1.pom">
+            <sha256 value="d2b115634f5c085db4b9c9ffc2658e89e231fdbfbe2242121a1cd95d4d948dd7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.code.gson" name="gson-parent" version="2.10.1">
+         <artifact name="gson-parent-2.10.1.pom">
+            <sha256 value="4248e0882426c615182385d6086c3ef3262e769957189e29306280b85482b833" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.errorprone" name="error_prone_annotations" version="2.23.0">
+         <artifact name="error_prone_annotations-2.23.0.jar">
+            <sha256 value="ec6f39f068b6ff9ac323c68e28b9299f8c0a80ca512dccb1d4a70f40ac3ec054" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="error_prone_annotations-2.23.0.pom">
+            <sha256 value="d5abb17f231b63bf009358fa640281b744810cb9587e5994977834959c07dbd8" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.errorprone" name="error_prone_parent" version="2.23.0">
+         <artifact name="error_prone_parent-2.23.0.pom">
+            <sha256 value="f5470a4b3104fe309fbe94a80d16c3c54d20f748f4c5de4f68a428688f30cbd4" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.guava" name="failureaccess" version="1.0.1">
+         <artifact name="failureaccess-1.0.1.jar">
+            <sha256 value="a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="failureaccess-1.0.1.pom">
+            <sha256 value="e96042ce78fecba0da2be964522947c87b40a291b5fd3cd672a434924103c4b9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.guava" name="guava" version="32.1.3-jre">
+         <artifact name="guava-32.1.3-jre.jar">
+            <sha256 value="6d4e2b5a118aab62e6e5e29d185a0224eed82c85c40ac3d33cf04a270c3b3744" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="guava-32.1.3-jre.module">
+            <sha256 value="f5fff7642c12e7627bc14289fd267e2602c17f9590e23522c3e63107f61c2942" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.guava" name="guava-bom" version="32.1.3-jre">
+         <artifact name="guava-bom-32.1.3-jre.pom">
+            <sha256 value="277512dbabef188055e50dc9f63d6b2e2b3053c43b6a7a2449b1b8105130b6e0" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.guava" name="guava-parent" version="26.0-android">
+         <artifact name="guava-parent-26.0-android.pom">
+            <sha256 value="f8698ab46ca996ce889c1afc8ca4f25eb8ac6b034dc898d4583742360016cc04" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.guava" name="guava-parent" version="32.1.3-jre">
+         <artifact name="guava-parent-32.1.3-jre.pom">
+            <sha256 value="f283c1f04897a9a88a3fa4ff46804e65e82114809a09cd04094bf7de01b1857b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.guava" name="listenablefuture" version="9999.0-empty-to-avoid-conflict-with-guava">
+         <artifact name="listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar">
+            <sha256 value="b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom">
+            <sha256 value="18d4b1db26153d4e55079ce1f76bb1fe05cdb862ef9954a88cbcc4ff38b8679b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.http-client" name="google-http-client" version="1.43.3">
+         <artifact name="google-http-client-1.43.3.jar">
+            <sha256 value="60aca7428c5a1ff3655b70541a98ff3d70dded48ac1324dae1af39f1b61914af" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-http-client-1.43.3.pom">
+            <sha256 value="54f7533dbbe7691797c623261ee7e26159a82f24cc205091756b2269f2b52deb" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.http-client" name="google-http-client-apache-v2" version="1.43.3">
+         <artifact name="google-http-client-apache-v2-1.43.3.jar">
+            <sha256 value="4cc8485bdda05607c7d8b95b130168ac82ad80bb3618c608fbf941047a96ac3b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-http-client-apache-v2-1.43.3.pom">
+            <sha256 value="6ff6acdef44df1a54a0bc9e3115c05e01753c80c811d560971bf93f944077320" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.http-client" name="google-http-client-appengine" version="1.43.3">
+         <artifact name="google-http-client-appengine-1.43.3.jar">
+            <sha256 value="66ade3c0e73566ed231032a2bda9f2f8e50e74911f6720bf0ee5233f6e5e033e" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-http-client-appengine-1.43.3.pom">
+            <sha256 value="468f0bd88f81e445cce434b1826ff4dd9e5fa975db310dad130a200b276af4ad" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.http-client" name="google-http-client-bom" version="1.42.0">
+         <artifact name="google-http-client-bom-1.42.0.pom">
+            <sha256 value="98ff616525e63fd06132215901538e23ff67aedb8934cd25dc59248f0cc0538c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.http-client" name="google-http-client-bom" version="1.42.3">
+         <artifact name="google-http-client-bom-1.42.3.pom">
+            <sha256 value="4a594f4a68be91e32a57b91e23da654068b12ed22f79805fbcd62261f50b47ec" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.http-client" name="google-http-client-bom" version="1.43.3">
+         <artifact name="google-http-client-bom-1.43.3.pom">
+            <sha256 value="2bd0ba17dcdab5c043b475d04775caa611d420dc56108b18e34d93d279b026b9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.http-client" name="google-http-client-gson" version="1.43.3">
+         <artifact name="google-http-client-gson-1.43.3.jar">
+            <sha256 value="e31a4edcb9c83954a2587e14fa2f3f8f4aad56152381b3321a3bd0bcae03fa26" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-http-client-gson-1.43.3.pom">
+            <sha256 value="2b2014f9f6498a9952294bd6f73c8b51f77966a5eced12029bfd3db676ab70f9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.http-client" name="google-http-client-jackson2" version="1.43.3">
+         <artifact name="google-http-client-jackson2-1.43.3.jar">
+            <sha256 value="8157f93ce7b51a013ea8c514413db6647056e39d7acb829bfc5da5b3bd25db3e" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-http-client-jackson2-1.43.3.pom">
+            <sha256 value="ab33a46c83802edc2877afbaa9fc38a34470ed8d3005b2341db16462e6b26530" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.http-client" name="google-http-client-parent" version="1.43.3">
+         <artifact name="google-http-client-parent-1.43.3.pom">
+            <sha256 value="1b4beedc67dcc082164b001eeca6c5129807b381986afd4672fe6d9d168c651b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.j2objc" name="j2objc-annotations" version="2.8">
+         <artifact name="j2objc-annotations-2.8.jar">
+            <sha256 value="f02a95fa1a5e95edb3ed859fd0fb7df709d121a35290eff8b74dce2ab7f4d6ed" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="j2objc-annotations-2.8.pom">
+            <sha256 value="37f87798b18385113c918bfa9e1276fe50735ef8fa849b5800c519d54dbf11f8" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.oauth-client" name="google-oauth-client" version="1.34.1">
+         <artifact name="google-oauth-client-1.34.1.jar">
+            <sha256 value="193edf97aefa28b93c5892bdc598bac34fa4c396588030084f290b1440e8b98a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="google-oauth-client-1.34.1.pom">
+            <sha256 value="c85f4751ea6cb0e1ec4f113033cf4e761c3abda6d7f410c9d6a426a545ab829b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.oauth-client" name="google-oauth-client-bom" version="1.34.1">
+         <artifact name="google-oauth-client-bom-1.34.1.pom">
+            <sha256 value="e96381ab4673f56de00d6c5b470c27b2316e678c2bffc20aea8cdf32a72e213e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.oauth-client" name="google-oauth-client-parent" version="1.34.1">
+         <artifact name="google-oauth-client-parent-1.34.1.pom">
+            <sha256 value="378b0758655e9d60fdde08da885d15838040bcbdf88afad7aed10af157b4403f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.protobuf" name="protobuf-bom" version="3.25.1">
+         <artifact name="protobuf-bom-3.25.1.pom">
+            <sha256 value="43786970c1acb7c119c961f53ea856a4bc0bf6bf0ceffab0ad2a84f262cf1654" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.protobuf" name="protobuf-java" version="3.25.1">
+         <artifact name="protobuf-java-3.25.1.jar">
+            <sha256 value="48a8e58a1a8f82eff141a7a388d38dfe77d7a48d5e57c9066ee37f19147e20df" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="protobuf-java-3.25.1.pom">
+            <sha256 value="3ff4a78d605e1d6991e515c5503726cb48042b874ea554a4bc8a87ae9f91bf95" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.protobuf" name="protobuf-java-util" version="3.25.1">
+         <artifact name="protobuf-java-util-3.25.1.jar">
+            <sha256 value="faf398ad0fe8c5a7d867f76d322e2e71bb31898fe86ec3223f787a6ed6fb4622" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="protobuf-java-util-3.25.1.pom">
+            <sha256 value="c7a271d4ebdbe41e9fcc2d4584730dc644b17272f9bafd14e3e6c8fb3a233b78" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.protobuf" name="protobuf-parent" version="3.25.1">
+         <artifact name="protobuf-parent-3.25.1.pom">
+            <sha256 value="cd1be83739f036462b129b653759fa868bfad43fb9539c5e7d1de2ac3d85dcea" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.google.re2j" name="re2j" version="1.7">
+         <artifact name="re2j-1.7.jar">
+            <sha256 value="4f657af51ab8bb0909bcc3eb40862d26125af8cbcf92aaaba595fed77f947bc0" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="re2j-1.7.pom">
+            <sha256 value="8bb0b7ae941f572cc49c7d0315da477fcf701c59193c96a5a8fe2d59c0957a9a" origin="Generated by Gradle"/>
          </artifact>
       </component>
       <component group="com.gradle.plugin-publish" name="com.gradle.plugin-publish.gradle.plugin" version="1.1.0">
          <artifact name="com.gradle.plugin-publish.gradle.plugin-1.1.0.pom">
-            <sha256 value="976c7c0769e0a07d15042480c6fe94a2c73424af995db585608173007d900214" origin="Generated by Gradle" reason="Artifact is not signed"/>
+            <sha256 value="976c7c0769e0a07d15042480c6fe94a2c73424af995db585608173007d900214" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.gradle.publish" name="plugin-publish-plugin" version="1.1.0">
+         <artifact name="plugin-publish-plugin-1.1.0.jar">
+            <sha256 value="5c04a916d21dc8e08d15b18af723c0d377fbadab00d45948724b6e641487d9c9" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="plugin-publish-plugin-1.1.0.module">
+            <sha256 value="8f59de7aef544a8f7288473b49fdbef3dcace24d08f4ad243d2db4ff33651d6d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.oracle.database.jdbc" name="ojdbc-bom" version="21.5.0.0">
+         <artifact name="ojdbc-bom-21.5.0.0.pom">
+            <sha256 value="33b0a2d209fa4973a16995935aae4d58f49d8bd00f89783ddd4b2e0d52b8c2ee" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.querydsl" name="querydsl-bom" version="5.0.0">
+         <artifact name="querydsl-bom-5.0.0.pom">
+            <sha256 value="33d88ac02fc8c1bdac129dc118ffda3b17fe96bf5cf83541ddc014a29b627b1b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.squareup.okhttp3" name="okhttp" version="4.12.0">
+         <artifact name="okhttp-4.12.0.jar">
+            <sha256 value="b1050081b14bb7a3a7e55a4d3ef01b5dcfabc453b4573a4fc019767191d5f4e0" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="okhttp-4.12.0.module">
+            <sha256 value="607e220ff8215b929d829bbf54f332894f1459b4d795979aeafcbcc1cea54cf3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.squareup.okhttp3" name="okhttp-bom" version="4.12.0">
+         <artifact name="okhttp-bom-4.12.0.module">
+            <sha256 value="7e0e2f347b1b636d92b043199e51403e15f09fb4ac46e8c163551a582b7b06bc" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.squareup.okhttp3" name="okhttp-bom" version="4.9.3">
+         <artifact name="okhttp-bom-4.9.3.pom">
+            <sha256 value="9912c0b1f30acfbb1314280b7fc7e73ae95faa23218d159dbeecbf164e2a0edc" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.squareup.okio" name="okio" version="3.6.0">
+         <artifact name="okio-3.6.0.module">
+            <sha256 value="6a47ac50364e6598459401fb86f9b6cfcdf637b9b3a3045b1cc33cbf4c408218" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="okio-metadata-3.6.0-all.jar">
+            <sha256 value="2bbd3f0645a3ada7e6532b2e6db471af4861464e1a140f95f807dfd16aa049e3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.squareup.okio" name="okio-jvm" version="3.6.0">
+         <artifact name="okio-jvm-3.6.0.jar">
+            <sha256 value="67543f0736fc422ae927ed0e504b98bc5e269fda0d3500579337cb713da28412" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="okio-jvm-3.6.0.module">
+            <sha256 value="b1c2199e1c0cc969ef61cbbe4af2ecaf9b06411bdde01cbaf6fc9134dfe04e8a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.squareup.retrofit2" name="converter-gson" version="2.9.0">
+         <artifact name="converter-gson-2.9.0.jar">
+            <sha256 value="32aa206b9a29c9df5eda93a092cfb3b0b9133e232c062baa882f0319f0e79f0e" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="converter-gson-2.9.0.pom">
+            <sha256 value="62782a151a64db28c02dd92026a3867baf34d1a8f249f8942c32dff4b5a5e78f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.squareup.retrofit2" name="retrofit" version="2.9.0">
+         <artifact name="retrofit-2.9.0.jar">
+            <sha256 value="e6ea1929c46852f5bec66ab3357da383476cef4e8d1deefdbf195b79cc4d6581" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="retrofit-2.9.0.pom">
+            <sha256 value="f7e96a31ded699ee36c4e77695c7c1868aa6b4c64bf998f9dfe0c66f25d0e493" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.sun.activation" name="all" version="1.2.2">
+         <artifact name="all-1.2.2.pom">
+            <sha256 value="1973d499cc2c1264aff2d6d052a1c716ae613d018ae1c2f610dd6a4d1c24578e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.sun.activation" name="jakarta.activation" version="1.2.2">
+         <artifact name="jakarta.activation-1.2.2.jar">
+            <sha256 value="02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jakarta.activation-1.2.2.pom">
+            <sha256 value="a8c937450f84f637f624923ba39392bf645c2d5eb2ffc7a1821d7f2e85561028" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.sun.istack" name="istack-commons" version="3.0.12">
+         <artifact name="istack-commons-3.0.12.pom">
+            <sha256 value="b399c16967129dd66447c262b435ad0b47706a5b2a57f28ef05a5a979d034069" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.sun.istack" name="istack-commons-runtime" version="3.0.12">
+         <artifact name="istack-commons-runtime-3.0.12.jar">
+            <sha256 value="27d85fc134c9271d5c79d3300fc4669668f017e72409727c428f54f2417f04cd" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="istack-commons-runtime-3.0.12.pom">
+            <sha256 value="83fdaf19ae0538e9e6b3cdde3d04d13be3969f490824a27decc80f21d604dfb6" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.sun.xml.bind" name="jaxb-bom-ext" version="2.3.7">
+         <artifact name="jaxb-bom-ext-2.3.7.pom">
+            <sha256 value="d8f23c4ff6e0f296242a322ad0f3a00e958b29ca18d95e663cca7c6015f7fe0b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.sun.xml.bind.mvn" name="jaxb-parent" version="2.3.7">
+         <artifact name="jaxb-parent-2.3.7.pom">
+            <sha256 value="9f0cfcfcedae49f1bb10e8f85c087236eeae77a81aefec04ddb586308d81ce2d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.sun.xml.bind.mvn" name="jaxb-runtime-parent" version="2.3.7">
+         <artifact name="jaxb-runtime-parent-2.3.7.pom">
+            <sha256 value="3aef96cf5f5f609499811d7d5fa1e265e528b9bf31eadd3fd05a31dfb24e3010" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="com.sun.xml.bind.mvn" name="jaxb-txw-parent" version="2.3.7">
+         <artifact name="jaxb-txw-parent-2.3.7.pom">
+            <sha256 value="c4f517d5b23d4619e7d82ad1dc2f27449b5554030ac1c4bf4a8bdbc47a25b9b4" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="commons-codec" name="commons-codec" version="1.15">
+         <artifact name="commons-codec-1.15.jar">
+            <sha256 value="b3e9f6d63a790109bf0d056611fbed1cf69055826defeb9894a71369d246ed63" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="commons-codec-1.15.pom">
+            <sha256 value="c86ee198a35a3715487860f419cbf642e7e4d9e8714777947dbe6a4e3a20ab58" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="commons-codec" name="commons-codec" version="1.16.0">
+         <artifact name="commons-codec-1.16.0.jar">
+            <sha256 value="56595fb20b0b85bc91d0d503dad50bb7f1b9afc0eed5dffa6cbb25929000484d" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="commons-codec-1.16.0.pom">
+            <sha256 value="6cb5957819df393956fd311a3a0c3f5eec1ebc49ba5b2d09f3f44e6167fa3e74" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="commons-io" name="commons-io" version="2.11.0">
+         <artifact name="commons-io-2.11.0.jar">
+            <sha256 value="961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="commons-io-2.11.0.pom">
+            <sha256 value="2e016fd7e3244b5f2c20acad834d93aa4790486ee1e4564641361a3e831eef59" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="commons-logging" name="commons-logging" version="1.2">
+         <artifact name="commons-logging-1.2.jar">
+            <sha256 value="daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="commons-logging-1.2.pom">
+            <sha256 value="c91ab5aa570d86f6fd07cc158ec6bc2c50080402972ee9179fe24100739fbb20" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.dropwizard.metrics" name="metrics-bom" version="4.2.13">
+         <artifact name="metrics-bom-4.2.13.pom">
+            <sha256 value="290431bdeb96f44026bec35bee3f35836ad40f472ee3700f31b8a8b9a2de0abd" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.dropwizard.metrics" name="metrics-parent" version="4.2.13">
+         <artifact name="metrics-parent-4.2.13.pom">
+            <sha256 value="381d660ec90816fa6f34802ee48eb1879dbb5c900cc5671a1484904f2750e9ec" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-alts" version="1.59.1">
+         <artifact name="grpc-alts-1.59.1.jar">
+            <sha256 value="9e5e7e83819123b7d8fddcbda8871b39ff366ba8339ec984d02279bab43f9fde" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-alts-1.59.1.pom">
+            <sha256 value="6461668ba2059170cb4f58fe687d05276b1d30ff5edacd098ae8726e6609672c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-api" version="1.59.1">
+         <artifact name="grpc-api-1.59.1.jar">
+            <sha256 value="c7950f19abe8289f54fdf887d235eb989337929390d534a0dcb3cbe731cd2ac2" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-api-1.59.1.pom">
+            <sha256 value="b5dad124d17f75979a0f845ee6248ab6a7c8f04912172b473bc48d2617a76988" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-auth" version="1.59.1">
+         <artifact name="grpc-auth-1.59.1.jar">
+            <sha256 value="d30a336d7c982875dd1510f130f2bba190642ed608de7abf62e0e1b0056e6096" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-auth-1.59.1.pom">
+            <sha256 value="580c5b80e37b665aaf2441b6535b8b16f20745679b0f6160a4de16c7f8acffd9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-bom" version="1.59.1">
+         <artifact name="grpc-bom-1.59.1.pom">
+            <sha256 value="6fd5eea3e386451ba00f609fba4b02995bdc4cfc0c317f48496433f35ccff841" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-context" version="1.59.1">
+         <artifact name="grpc-context-1.59.1.jar">
+            <sha256 value="056bde0434b2bf30fe074a87223447a7745f8deb28a045362570c65988a69383" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-context-1.59.1.pom">
+            <sha256 value="e163c92beb20d195b2c246b3d952b89b207c209d2534466ce9af014483b6827b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-core" version="1.59.1">
+         <artifact name="grpc-core-1.59.1.jar">
+            <sha256 value="db80d044f30f687513d6416ddf0d863b070ce6663ac3cb79ab16e5376d51501c" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-core-1.59.1.pom">
+            <sha256 value="5dad0d3a4369cee69b0d5e6f6e3dc986efa0b5309085c96f5f49dbc5aa46c3f5" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-googleapis" version="1.59.1">
+         <artifact name="grpc-googleapis-1.59.1.jar">
+            <sha256 value="51a904f45667ac66e7227c25beda67e245006286714107f7bf97a84c3b4b13d3" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-googleapis-1.59.1.pom">
+            <sha256 value="27f015ee24c9169bb8de4cf14c9cbf53e110ef4bec807cd982c7d2b6489013a2" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-grpclb" version="1.59.1">
+         <artifact name="grpc-grpclb-1.59.1.jar">
+            <sha256 value="5932d3dbf76e3748bedcde9c7c0b5cb692ead801eb610424a41412f6ce0ba7f3" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-grpclb-1.59.1.pom">
+            <sha256 value="8e3a40cd2f32ad067165db9fee095461cc6bada0b6335cf6341eeb27963757ac" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-inprocess" version="1.59.1">
+         <artifact name="grpc-inprocess-1.59.1.jar">
+            <sha256 value="3407bdff81acf861c8b4e0d228df4f7f12fb902f8edb2e793faf0fb09bd5af0d" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-inprocess-1.59.1.pom">
+            <sha256 value="9ea9cb44db93019dfefaa68c4883a6cbb3ea9285624a1e79cdd739026b89828f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-netty-shaded" version="1.59.1">
+         <artifact name="grpc-netty-shaded-1.59.1.jar">
+            <sha256 value="75dc5d37ffab389a211aeddd25fce5c53c44eb04d734149b30e45cf0892724e1" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-netty-shaded-1.59.1.pom">
+            <sha256 value="85d5b54aa17b5b129a938a3955e6e46d3011d7e4b34a7014796efc0c3b8aaf95" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-protobuf" version="1.59.1">
+         <artifact name="grpc-protobuf-1.59.1.jar">
+            <sha256 value="4755cc5c9b08961e240268b260ca11ee178ca29d29b9afef2a334f7f9c525d00" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-protobuf-1.59.1.pom">
+            <sha256 value="8473988d5ffb809ca8f3a6c3ca02886b45bb0458dc09079036cfdeba37615087" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-protobuf-lite" version="1.59.1">
+         <artifact name="grpc-protobuf-lite-1.59.1.jar">
+            <sha256 value="5a3e34f19f49d5031e9e0194909cbe22fce6177413c019b4ff3b01174815c7ca" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-protobuf-lite-1.59.1.pom">
+            <sha256 value="e64a852d8bb378ec5a3a116ba520649b1c5b6a26efa907b03798d91ac199c21c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-rls" version="1.59.1">
+         <artifact name="grpc-rls-1.59.1.jar">
+            <sha256 value="752045ab5303278858289c2f5631cbe9521371e819b23ef0971fc1b2c4f30c20" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-rls-1.59.1.pom">
+            <sha256 value="b0d6935e7f133682eb32df9fd32501676bba756960d19027f1523368d4643afc" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-services" version="1.59.1">
+         <artifact name="grpc-services-1.59.1.jar">
+            <sha256 value="abcd8a93324b522857261e48c4593d44f238b2f3052fd8e7d29b04b02a9ce8f8" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-services-1.59.1.pom">
+            <sha256 value="2904013db25cce523bd42a54f306100e14935b9d7931127eb527ab71f437e576" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-stub" version="1.59.1">
+         <artifact name="grpc-stub-1.59.1.jar">
+            <sha256 value="e16a22045eee6c135c6a41448bf234a5b8b79eb27373848137489fd5d30da5e2" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-stub-1.59.1.pom">
+            <sha256 value="eb2a3086131b0b883c1557b79aacafe7db8da7fb52385984fb617e6e053f5c60" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-util" version="1.59.1">
+         <artifact name="grpc-util-1.59.1.jar">
+            <sha256 value="d9ebfcd9cdc106e0a34e97de66a8da2cdbbb7ef1cbdde9aa259fdd4756959f68" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-util-1.59.1.pom">
+            <sha256 value="9d4400208171c0c045c4822d6c67b1de24fae1f9869d6ca29b12547629660d47" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.grpc" name="grpc-xds" version="1.59.1">
+         <artifact name="grpc-xds-1.59.1.jar">
+            <sha256 value="9190d9ac0fc176e2398d15c0e8b327505c4d56b53850e935bbf48b29de546d0a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="grpc-xds-1.59.1.pom">
+            <sha256 value="dbb573fd425edcfc95724b890030391d07b57aeaf98fb3c62dd0f0d5cd816f46" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.micrometer" name="micrometer-bom" version="1.9.6">
+         <artifact name="micrometer-bom-1.9.6.pom">
+            <sha256 value="3db66e82bf86b24c8879762319b148b694c6d7d921cd71a9de8306b8c90f7327" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.micrometer" name="micrometer-core" version="1.9.6">
+         <artifact name="micrometer-core-1.9.6.jar">
+            <sha256 value="288eb4091f1df06ba31a887bc5437ed313229c4d70777efd130769b4ee413562" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="micrometer-core-1.9.6.pom">
+            <sha256 value="cd7beedee1a52b8b9e57d0d50b9153cf6b134823bce91e38c662ca25df6a20d3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-bom" version="4.1.85.Final">
+         <artifact name="netty-bom-4.1.85.Final.pom">
+            <sha256 value="0d197efa125fc4d1574b9e29252bfd242cd0777fb7911129a082dc28e43c45aa" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-buffer" version="4.1.107.Final">
+         <artifact name="netty-buffer-4.1.107.Final.jar">
+            <sha256 value="04eb1231c86a7011c48cd443a25dc2f397137e5ee0aac2f12f1c503f11f09e2a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-buffer-4.1.107.Final.pom">
+            <sha256 value="fcaf25420ba99a6701cf74718677411498fdb1fad4d75734d35fd8ef4a6ee945" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-codec" version="4.1.107.Final">
+         <artifact name="netty-codec-4.1.107.Final.jar">
+            <sha256 value="3a1f361b405f9ea30fe6aabe1907d719c0c99fe30c03932fee558214dbd638cc" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-codec-4.1.107.Final.pom">
+            <sha256 value="f6fc4019ce6e5c75d9ced34a6b6dccf23f283b9bb3622e14d9826d62bbeef71c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-codec-http" version="4.1.107.Final">
+         <artifact name="netty-codec-http-4.1.107.Final.jar">
+            <sha256 value="0f35f57ecc11e1227d0c65d65582adc1075474a30a8fd3cff0f6e9a66c9e2a74" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-codec-http-4.1.107.Final.pom">
+            <sha256 value="af8cad175654ef86695d5134fffa11b3a03fed1f011ca9ce0c6091bd9d4d9a90" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-codec-http2" version="4.1.107.Final">
+         <artifact name="netty-codec-http2-4.1.107.Final.jar">
+            <sha256 value="5d83fe14a537ea6ddecc782df256da23ee49754044a4cacc2d8ec5225f338c72" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-codec-http2-4.1.107.Final.pom">
+            <sha256 value="4f4a1939f69fd8ea04e0da24c5b77f957be9f21defee16bc4e197a0f8f4e2817" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-common" version="4.1.107.Final">
+         <artifact name="netty-common-4.1.107.Final.jar">
+            <sha256 value="1231e7bd5f523d97280b89adefb3521132d45c22791318b9e0d462bd3ba1b8e9" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-common-4.1.107.Final.pom">
+            <sha256 value="fa55bbee48c7b3b4e62da28a278ea5c45558719991519b7b9da79a27e1107e4b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-handler" version="4.1.107.Final">
+         <artifact name="netty-handler-4.1.107.Final.jar">
+            <sha256 value="ce135be15a4afe717db7c5a1d5bf1d10bdfdee50c8ce77a5a39e4694b97071db" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-handler-4.1.107.Final.pom">
+            <sha256 value="c6c59fd6f0f70a043a50a5826de7ad68dbb95d341e03bd1bbe179038e48b845e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-parent" version="4.1.107.Final">
+         <artifact name="netty-parent-4.1.107.Final.pom">
+            <sha256 value="9825c420d8c47c9c921dbc9caa8acafc3075129353fb1b07c8cec1b5b8fb1eb1" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-resolver" version="4.1.107.Final">
+         <artifact name="netty-resolver-4.1.107.Final.jar">
+            <sha256 value="303244791c040229315845e2236bb7b75249cffb308f99d48b0bab199bc6be63" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-resolver-4.1.107.Final.pom">
+            <sha256 value="5309429ef003f480a5af7fba7d2d3e55f945bb252f218cbaaac68d0e70d7a885" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-transport" version="4.1.107.Final">
+         <artifact name="netty-transport-4.1.107.Final.jar">
+            <sha256 value="8b3107c684c5fcf53bc437e78db9f186008184210fdb96798efb835c073cfa86" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-transport-4.1.107.Final.pom">
+            <sha256 value="7910d69667fb38b3b4a004715806508edbb905cc8175030ca230ec5b44f6fc0b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-transport-classes-epoll" version="4.1.107.Final">
+         <artifact name="netty-transport-classes-epoll-4.1.107.Final.jar">
+            <sha256 value="3ca736cb7e02cca5fd600d9e12b2c068d35bbbb13440c507b4e8f6569133c012" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-transport-classes-epoll-4.1.107.Final.pom">
+            <sha256 value="909918f5903860ead20e3b5c27ec75505be1a715356ff75c8ab169c4cc289be6" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.netty" name="netty-transport-native-unix-common" version="4.1.107.Final">
+         <artifact name="netty-transport-native-unix-common-4.1.107.Final.jar">
+            <sha256 value="40eb2e471d88f9e7d09d59284297d1d46de37fb1441215b1b73e9b8691061e27" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-transport-native-unix-common-4.1.107.Final.pom">
+            <sha256 value="900b7f63a18b30feb4fb058decb328c0dc7e5a0af31bb32d6cc4fd9273f846b7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.opencensus" name="opencensus-api" version="0.31.1">
+         <artifact name="opencensus-api-0.31.1.jar">
+            <sha256 value="f1474d47f4b6b001558ad27b952e35eda5cc7146788877fc52938c6eba24b382" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="opencensus-api-0.31.1.pom">
+            <sha256 value="556f427e12090efb36a6087f7410abfe45de10107292d96fa63e4175174ecb76" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.opencensus" name="opencensus-contrib-http-util" version="0.31.1">
+         <artifact name="opencensus-contrib-http-util-0.31.1.jar">
+            <sha256 value="3ea995b55a4068be22989b70cc29a4d788c2d328d1d50613a7a9afd13fdd2d0a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="opencensus-contrib-http-util-0.31.1.pom">
+            <sha256 value="ebe22c422217d662c7cee99476f0b52c80577ed445786ac299251befaa4c075b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.opencensus" name="opencensus-proto" version="0.2.0">
+         <artifact name="opencensus-proto-0.2.0.jar">
+            <sha256 value="0c192d451e9dd74e98721b27d02f0e2b6bca44b51563b5dabf2e211f7a3ebf13" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="opencensus-proto-0.2.0.pom">
+            <sha256 value="b7087907920fc8a81534686b2f1a2b331127af97f015abbdb3786a51f3fa1e52" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.perfmark" name="perfmark-api" version="0.26.0">
+         <artifact name="perfmark-api-0.26.0.jar">
+            <sha256 value="b7d23e93a34537ce332708269a0d1404788a5b5e1949e82f5535fce51b3ea95b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="perfmark-api-0.26.0.module">
+            <sha256 value="31d832332474ce48150f5bae003343319136f336afd1076a289029319e3ea97a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.projectreactor" name="reactor-bom" version="2020.0.25">
+         <artifact name="reactor-bom-2020.0.25.pom">
+            <sha256 value="55a483e0235f494fdebc57094c1ae61314aecce9cc19c4bee91f11f276682982" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.prometheus" name="parent" version="0.15.0">
+         <artifact name="parent-0.15.0.pom">
+            <sha256 value="e8e10f63abf4796a9db6654f92146473e75da7e2ad443066b812f85e88cfc6e7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.prometheus" name="simpleclient_bom" version="0.15.0">
+         <artifact name="simpleclient_bom-0.15.0.pom">
+            <sha256 value="23547fb1987aa1d5369026b633dae141a33d228380f360fd78c3b413e6636329" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.r2dbc" name="r2dbc-bom" version="Borca-SR2">
+         <artifact name="r2dbc-bom-Borca-SR2.pom">
+            <sha256 value="100be727561a165c67df61dc2a3ba2f0170bfa01e01bb3f7b929e8db8d856299" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.rest-assured" name="rest-assured-bom" version="4.5.1">
+         <artifact name="rest-assured-bom-4.5.1.pom">
+            <sha256 value="c2d9fbe28a1c39d812960b699a09fb7c56f533cb20fc95a99cb8dc6a87957bee" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="io.rsocket" name="rsocket-bom" version="1.1.3">
+         <artifact name="rsocket-bom-1.1.3.pom">
+            <sha256 value="e5ccd8fed3415bb4385e4d0787e3e33624cb2c7c002d2550c39788f2bb9b0fae" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="jakarta.annotation" name="ca-parent" version="1.3.5">
+         <artifact name="ca-parent-1.3.5.pom">
+            <sha256 value="bdbb049465f366edb5a4adbff293a841c9b75b238519e76f86fe4f7bfb9d7e2d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="jakarta.annotation" name="jakarta.annotation-api" version="1.3.5">
+         <artifact name="jakarta.annotation-api-1.3.5.jar">
+            <sha256 value="85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jakarta.annotation-api-1.3.5.pom">
+            <sha256 value="ba6874767f5415c5e0f644fab80e1bad5feab6d18150f22638067681866feaaf" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="jakarta.servlet" name="jakarta.servlet-api" version="4.0.4">
+         <artifact name="jakarta.servlet-api-4.0.4.jar">
+            <sha256 value="586e27706c21258f5882f43be06904f49b02db9ac54e345d393fe4a32494d127" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jakarta.servlet-api-4.0.4.pom">
+            <sha256 value="69d38645ea5785b76c299890208ed1dc3bb9152591ebd2025f6193dd7ceb3d27" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="jakarta.websocket" name="jakarta.websocket-all" version="1.1.2">
+         <artifact name="jakarta.websocket-all-1.1.2.pom">
+            <sha256 value="e90df756a815a1b1e5d6fb5ec8f7d4ad789d8657aec004b9f259343539368fab" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="jakarta.websocket" name="jakarta.websocket-api" version="1.1.2">
+         <artifact name="jakarta.websocket-api-1.1.2.jar">
+            <sha256 value="e2f4e99e04130a29fc8e57e334fa029e96e2ca6672ba0166585c59d19798904c" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jakarta.websocket-api-1.1.2.pom">
+            <sha256 value="416a3129537b61805c7049796f0ccf62863efd0f44f0140090de271e1b23baf9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="jakarta.xml.bind" name="jakarta.xml.bind-api" version="2.3.3">
+         <artifact name="jakarta.xml.bind-api-2.3.3.jar">
+            <sha256 value="c04539f472e9a6dd0c7685ea82d677282269ab8e7baca2e14500e381e0c6cec5" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jakarta.xml.bind-api-2.3.3.pom">
+            <sha256 value="7fe2ca5dce4b14a646bbf921d13ca42caf2a2c0654da155c7563865c989396fd" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="jakarta.xml.bind" name="jakarta.xml.bind-api-parent" version="2.3.3">
+         <artifact name="jakarta.xml.bind-api-parent-2.3.3.pom">
+            <sha256 value="280da531760166d4412368d0dd899ef4aebfd0a7d82bf233502e29856806ada9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="javax.annotation" name="javax.annotation-api" version="1.3.2">
+         <artifact name="javax.annotation-api-1.3.2.jar">
+            <sha256 value="e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="javax.annotation-api-1.3.2.pom">
+            <sha256 value="46a4a251ca406e78e4853d7a2bae83282844a4992851439ee9a1f23716f06b97" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="junit" name="junit" version="4.13.2">
+         <artifact name="junit-4.13.2.jar">
+            <sha256 value="8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="junit-4.13.2.pom">
+            <sha256 value="569b6977ee4603c965c1c46c3058fa6e969291b0160eb6964dd092cd89eadd94" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="net.java" name="jvnet-parent" version="3">
+         <artifact name="jvnet-parent-3.pom">
+            <sha256 value="30f5789efa39ddbf96095aada3fc1260c4561faf2f714686717cb2dc5049475a" origin="Generated by Gradle"/>
          </artifact>
       </component>
       <component group="org.apache" name="apache" version="13">
          <artifact name="apache-13.pom">
-            <pgp value="f254b35617dc255d9344bcfa873a8e86b4372146"/>
             <sha256 value="ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache" name="apache" version="21">
+         <artifact name="apache-21.pom">
+            <sha256 value="af10c108da014f17cafac7b52b2b4b5a3a1c18265fa2af97a325d9143537b380" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache" name="apache" version="23">
+         <artifact name="apache-23.pom">
+            <sha256 value="bc10624e0623f36577fac5639ca2936d3240ed152fb6d8d533ab4d270543491c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache" name="apache" version="24">
+         <artifact name="apache-24.pom">
+            <sha256 value="2e93bbabe3413af89a0c3bfb9e6bf71dbc9e8f9fb14ccbb1d78bd0275df1c525" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache" name="apache" version="29">
+         <artifact name="apache-29.pom">
+            <sha256 value="3e49037174820bbd0df63420a977255886398954c2a06291fa61f727ac35b377" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.commons" name="commons-lang3" version="3.12.0">
+         <artifact name="commons-lang3-3.12.0.jar">
+            <sha256 value="d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="commons-lang3-3.12.0.pom">
+            <sha256 value="82d31f1dcc4583effd744e979165b16da64bf86bca623fc5d1b03ed94f45c85a" origin="Generated by Gradle"/>
          </artifact>
       </component>
       <component group="org.apache.commons" name="commons-parent" version="34">
          <artifact name="commons-parent-34.pom">
-            <pgp value="d6f1bc78607808ec8e9f69437a8860944fad5f62"/>
             <sha256 value="3a2e69d06d641d1f3b293126dc9e2e4ea6563bf8c36c87e0ab6fa4292d04b79c" origin="Generated by Gradle"/>
          </artifact>
       </component>
       <component group="org.apache.commons" name="commons-parent" version="52">
          <artifact name="commons-parent-52.pom">
-            <pgp value="b6e73d84ea4fcc47166087253faad2cd5ecbb314"/>
             <sha256 value="75dbe8f34e98e4c3ff42daae4a2f9eb4cbcd3b5f1047d54460ace906dbb4502e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.commons" name="commons-parent" version="58">
+         <artifact name="commons-parent-58.pom">
+            <sha256 value="2d4b12e18899063abd7c75278b5fa97a3729d80878ceecb6a40d946e9c0d5590" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.httpcomponents" name="httpclient" version="4.5.13">
+         <artifact name="httpclient-4.5.13.jar">
+            <sha256 value="6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="httpclient-4.5.13.pom">
+            <sha256 value="78eb9ada74929fcd63d07adc4f49236841a45cc29d5f817bf45801f513fd7e6c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.httpcomponents" name="httpcomponents-client" version="4.5.13">
+         <artifact name="httpcomponents-client-4.5.13.pom">
+            <sha256 value="9cba594c08db7271d0c20e9845d622bb39e69583910b45e7d5df82f6058d4dd9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.httpcomponents" name="httpcomponents-core" version="4.4.13">
+         <artifact name="httpcomponents-core-4.4.13.pom">
+            <sha256 value="c554e7008e4517c7ef54e005cc8b74f4c87a54a0ea2c6f57be5d0569df51936b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.httpcomponents" name="httpcomponents-parent" version="11">
+         <artifact name="httpcomponents-parent-11.pom">
+            <sha256 value="a901f87b115c55070c7ee43efff63e20e7b02d30af2443ae292bf1f4e532d3aa" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.httpcomponents" name="httpcore" version="4.4.13">
+         <artifact name="httpcore-4.4.13.jar">
+            <sha256 value="e06e89d40943245fcfa39ec537cdbfce3762aecde8f9c597780d2b00c2b43424" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="httpcore-4.4.13.pom">
+            <sha256 value="8f812d9fa7b72a3d4aa7f825278932a5df344b42a6d8398905879431a1bf9a97" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.logging" name="logging-parent" version="5">
+         <artifact name="logging-parent-5.pom">
+            <sha256 value="dc7630cf82cb31f4d476216054221affd525746ee96541240f452f7323703022" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.logging.log4j" name="log4j" version="2.17.2">
+         <artifact name="log4j-2.17.2.pom">
+            <sha256 value="f4a7e1d387c1fb9b365d4cb36d270ef8634ba49ad205558c4e1cda7d41b523f5" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.logging.log4j" name="log4j-api" version="2.17.2">
+         <artifact name="log4j-api-2.17.2.jar">
+            <sha256 value="09351b5a03828f369cdcff76f4ed39e6a6fc20f24f046935d0b28ef5152f8ce4" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="log4j-api-2.17.2.pom">
+            <sha256 value="2b8f3f6d471df17969921a7f0ffda83e0628ab3defc7e5bca2aefed1667629ef" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.logging.log4j" name="log4j-bom" version="2.17.2">
+         <artifact name="log4j-bom-2.17.2.pom">
+            <sha256 value="ea37ad379f57276b9b0ae842dc17be35a685d62c6b210230a65b0a6681893bd1" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.logging.log4j" name="log4j-to-slf4j" version="2.17.2">
+         <artifact name="log4j-to-slf4j-2.17.2.jar">
+            <sha256 value="9bcfa5273527b950d79739d11e8f8080cfc881908fa2a946b4e891c0293094de" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="log4j-to-slf4j-2.17.2.pom">
+            <sha256 value="beaed694e82498c2dea2bd07a14138968c4a74d2e4c0769ee8d3cd32d57ecda9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.maven" name="maven" version="3.6.3">
+         <artifact name="maven-3.6.3.pom">
+            <sha256 value="d2d86245ea66149bc14d2dd72bbb961f964dd658b809a0573252c06531eeec16" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.maven" name="maven-model" version="3.6.3">
+         <artifact name="maven-model-3.6.3.jar">
+            <sha256 value="17cef1f58e146ef0d7d9e96b3b92d98a1d6fd7d2b3288ba538e8ff1e0d9160cf" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="maven-model-3.6.3.pom">
+            <sha256 value="7c720e8cb03d285c71cd6e334d9c9e596062bdd310ee0ad15f5c479a993154f0" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.maven" name="maven-parent" version="33">
+         <artifact name="maven-parent-33.pom">
+            <sha256 value="3856e3fcd169502d5f12fe2452604ebf6c7c025f15656bfa558ea99ed29d73ea" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.apache.tomcat.embed" name="tomcat-embed-el" version="9.0.69">
+         <artifact name="tomcat-embed-el-9.0.69.jar">
+            <sha256 value="73918e2ebdd0a7bb59e1a7febdc15ebf9cc4e0daa741ef5e68b0dc6c4156faed" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="tomcat-embed-el-9.0.69.pom">
+            <sha256 value="cd53dd92121a5b09b7549fb837e39d3d5eda5f0c88dd5f2866bcc21a373ba580" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.checkerframework" name="checker-qual" version="3.40.0">
+         <artifact name="checker-qual-3.40.0.jar">
+            <sha256 value="e8fce29a11df9934cf04df17bd629bfcf360b4b8ba5a8bd0457f6c4567d1fee4" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="checker-qual-3.40.0.module">
+            <sha256 value="0796d558de28c0fb7223be39f12cd5ed128b1e6f8548a11dcfc4f140341eb374" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.codehaus.groovy" name="groovy-bom" version="3.0.13">
+         <artifact name="groovy-bom-3.0.13.pom">
+            <sha256 value="5755cad1234d4a2e02dfe10637966fbee30bdb767bb01c137928a1d6184e7018" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.codehaus.mojo" name="animal-sniffer-annotations" version="1.23">
+         <artifact name="animal-sniffer-annotations-1.23.jar">
+            <sha256 value="9ffe526bf43a6348e9d8b33b9cd6f580a7f5eed0cf055913007eda263de974d0" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="animal-sniffer-annotations-1.23.pom">
+            <sha256 value="5610db06b733641acbc7a0c48a80c40069db627bad043f8c7c8d7afb4f6a3d27" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.codehaus.mojo" name="animal-sniffer-parent" version="1.23">
+         <artifact name="animal-sniffer-parent-1.23.pom">
+            <sha256 value="6b7f054ab86a87f8e2599f35808b0989922e86b6cab13988021cd12640a4b404" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.codehaus.mojo" name="mojo-parent" version="74">
+         <artifact name="mojo-parent-74.pom">
+            <sha256 value="1472325a16f0b1bdabed21fa4839372964944610294ce2681b2059edc654f2b3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.codehaus.woodstox" name="stax2-api" version="4.2.1">
+         <artifact name="stax2-api-4.2.1.jar">
+            <sha256 value="678567e48b51a42c65c699f266539ad3d676d4b1a5b0ad7d89ece8b9d5772579" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="stax2-api-4.2.1.pom">
+            <sha256 value="79da410c8c0f46a3f8e8adb30d6c24ccd6065b6ef6bfde87bd97e9881ea0a2e7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.conscrypt" name="conscrypt-openjdk-uber" version="2.5.2">
+         <artifact name="conscrypt-openjdk-uber-2.5.2.jar">
+            <sha256 value="eaf537d98e033d0f0451cd1b8cc74e02d7b55ec882da63c88060d806ba89c348" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="conscrypt-openjdk-uber-2.5.2.pom">
+            <sha256 value="b5fd548732f932545d777890eb995222bfe866232351be908137e39c3c672d8b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.ee4j" name="project" version="1.0.5">
+         <artifact name="project-1.0.5.pom">
+            <sha256 value="916b4794d8d8220a59a3fdf6a64dbe794aeb23395e888b81ae36a9b5a2c591a6" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.ee4j" name="project" version="1.0.6">
+         <artifact name="project-1.0.6.pom">
+            <sha256 value="4e7d8329d8da7dcf30779d824241be145f27108932f5a5a24eb907677bc8d72d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.ee4j" name="project" version="1.0.7">
+         <artifact name="project-1.0.7.pom">
+            <sha256 value="205c039a42cbae3556efbeb04a483eb3a3cf9550bd75bf84260dc8f28218f105" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-bom" version="9.4.49.v20220914">
+         <artifact name="jetty-bom-9.4.49.v20220914.pom">
+            <sha256 value="cf74a8d21de13eb446cdf75c86990152f96009eea26ed06041ec451e6d32418b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-continuation" version="9.4.49.v20220914">
+         <artifact name="jetty-continuation-9.4.49.v20220914.jar">
+            <sha256 value="d13b4df40102ffab8bc52834061e53ffed4e2678fa8cf30ed82153ebdda7b1e4" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-continuation-9.4.49.v20220914.pom">
+            <sha256 value="234ed5cd8f5f7150e39d1fd8221678a87d4aa41bd1a12d42499eac0b1a566256" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-http" version="9.4.49.v20220914">
+         <artifact name="jetty-http-9.4.49.v20220914.jar">
+            <sha256 value="c39bfec2941a45396bd67da1aea53ea587c97ca31fdcee0d8ea4351b9f043704" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-http-9.4.49.v20220914.pom">
+            <sha256 value="0f4929afeabcfbc87a8879eb8a2f1fd164a2cba17221d802bcd7589cf2eee429" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-io" version="9.4.49.v20220914">
+         <artifact name="jetty-io-9.4.49.v20220914.jar">
+            <sha256 value="9ee7fcec407cb4b16b252596d9b9a23b4ee9cd4cf65921ae95872684af083bb3" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-io-9.4.49.v20220914.pom">
+            <sha256 value="f80ea7c7c4fef6c5cd9797bada6221f83ce37d83f4e97c47383eb1789667471c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-project" version="9.4.49.v20220914">
+         <artifact name="jetty-project-9.4.49.v20220914.pom">
+            <sha256 value="1826850557018c25bafc37c774ba1f38032c9683eea83c42a7da4d9656514fe3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-security" version="9.4.49.v20220914">
+         <artifact name="jetty-security-9.4.49.v20220914.jar">
+            <sha256 value="5dd804fc4cf166b8106b06cb427b649f99cf36a48dbb0b19a88d76a9fb5c4e06" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-security-9.4.49.v20220914.pom">
+            <sha256 value="fc88abcfb6f24d813131e7cd78ed23d8b1c0f6f630105f62a2ccface7e62f2fc" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-server" version="9.4.49.v20220914">
+         <artifact name="jetty-server-9.4.49.v20220914.jar">
+            <sha256 value="06ae86baded124f81935a0701ed6af7b9e7ce33ee8ef58a87b779bb0a6b23dc4" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-server-9.4.49.v20220914.pom">
+            <sha256 value="6745bd595dfbd1226b3e377a717f655b05fc274391c4072f96176dc9d4c0caea" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-servlet" version="9.4.49.v20220914">
+         <artifact name="jetty-servlet-9.4.49.v20220914.jar">
+            <sha256 value="8bf6a78836715859789e9183f779ece85f769206c75e606c09cb1f03f0623334" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-servlet-9.4.49.v20220914.pom">
+            <sha256 value="f968cbe0cf7bdb931bbfe31251439bc433b5483346a8e2424ea79cd645561300" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-servlets" version="9.4.49.v20220914">
+         <artifact name="jetty-servlets-9.4.49.v20220914.jar">
+            <sha256 value="71e5b4aebd45943254c54ff67c2a2297473e6b480c268640176671507cfe7ff5" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-servlets-9.4.49.v20220914.pom">
+            <sha256 value="d54ec2afa6e631c0ef05cd5430c8cb5701768f91a29173c4e04358761456f83a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-util" version="9.4.49.v20220914">
+         <artifact name="jetty-util-9.4.49.v20220914.jar">
+            <sha256 value="679313e158f334135e0e80ac200fd6dea605cde73fd7bf255aaaf47773d2f801" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-util-9.4.49.v20220914.pom">
+            <sha256 value="429dfdc3bc7e4dfa394d87de603e007e89f9b790ce9e7ddc838cc2203f10e21c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-util-ajax" version="9.4.49.v20220914">
+         <artifact name="jetty-util-ajax-9.4.49.v20220914.jar">
+            <sha256 value="9a61fd75a52936aa6c6737e411ca81ada5203cd3d1371f3815644614b5ce7247" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-util-ajax-9.4.49.v20220914.pom">
+            <sha256 value="adf6254824d907e670de5979129b30223226ace17a011607ce998dadf8f255dd" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-webapp" version="9.4.49.v20220914">
+         <artifact name="jetty-webapp-9.4.49.v20220914.jar">
+            <sha256 value="33148b2a8e6eb3d426dd2b980e6deb67690b3978ad17759542488556b01cf401" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-webapp-9.4.49.v20220914.pom">
+            <sha256 value="4638ed08d8b7275d67bffa28e0f22f394ee6fb6b5a39a3d122e1b92194fe13f3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.eclipse.jetty" name="jetty-xml" version="9.4.49.v20220914">
+         <artifact name="jetty-xml-9.4.49.v20220914.jar">
+            <sha256 value="0047f7b8569bff65523c3023d1ac2e483faccb003dcf9e307763bc2d21aef85b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jetty-xml-9.4.49.v20220914.pom">
+            <sha256 value="a8edf27af6c841d1f4ccb334fa02505528cba7fe7f857743a490a408e7cc6e1d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.glassfish.jaxb" name="jaxb-bom" version="2.3.7">
+         <artifact name="jaxb-bom-2.3.7.pom">
+            <sha256 value="0d794580f883e0f029a0fe25fd07b2e6c07590732fb39fc50b96c3a202944a04" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.glassfish.jaxb" name="jaxb-runtime" version="2.3.7">
+         <artifact name="jaxb-runtime-2.3.7.jar">
+            <sha256 value="c048d9edde5d5d67bca4f66921ef1315b8e20b1a978b757d54cea0ea5ce1c907" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jaxb-runtime-2.3.7.pom">
+            <sha256 value="1939d36c9e6b41a806f69fb31d1df0adc35d2e18493207684ca8dfd8de8dece7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.glassfish.jaxb" name="txw2" version="2.3.7">
+         <artifact name="txw2-2.3.7.jar">
+            <sha256 value="4a52d7c42a7e6270c8d72554eb994059f53d69c2545fb2daa02c6e9bfbda8b22" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="txw2-2.3.7.pom">
+            <sha256 value="12ce51694a9f3c5fa31a1167e3ffccdef6708b0ea333817c9884231aae0d4834" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.glassfish.jersey" name="jersey-bom" version="2.35">
+         <artifact name="jersey-bom-2.35.pom">
+            <sha256 value="10d308e9c4cda17c348e78fa5db762a42b062476e3f0a2fdf084c171e286d087" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.hamcrest" name="hamcrest-core" version="1.3">
+         <artifact name="hamcrest-core-1.3.jar">
+            <sha256 value="66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="hamcrest-core-1.3.pom">
+            <sha256 value="fde386a7905173a1b103de6ab820727584b50d0e32282e2797787c20a64ffa93" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.hamcrest" name="hamcrest-parent" version="1.3">
+         <artifact name="hamcrest-parent-1.3.pom">
+            <sha256 value="6d535f94efb663bdb682c9f27a50335394688009642ba7a9677504bc1be4129b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.hdrhistogram" name="HdrHistogram" version="2.1.12">
+         <artifact name="HdrHistogram-2.1.12.jar">
+            <sha256 value="9b47fbae444feaac4b7e04f0ea294569e4bc282bc69d8c2ce2ac3f23577281e2" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="HdrHistogram-2.1.12.pom">
+            <sha256 value="7fb3e790c154d1b5e23170bb8cbf7f70ef0809af17229f1dcb010d7799651080" origin="Generated by Gradle"/>
          </artifact>
       </component>
       <component group="org.infinispan" name="infinispan-bom" version="11.0.15.Final">
          <artifact name="infinispan-bom-11.0.15.Final.pom">
-            <sha256 value="07386ee62c8464618770d209f8c060da8e51f56e76314d1b29caec9c302130e9" origin="Generated by Gradle" reason="Artifact is not signed"/>
+            <sha256 value="07386ee62c8464618770d209f8c060da8e51f56e76314d1b29caec9c302130e9" origin="Generated by Gradle"/>
          </artifact>
       </component>
       <component group="org.infinispan" name="infinispan-bom" version="13.0.12.Final">
@@ -236,7 +1457,7 @@
       </component>
       <component group="org.infinispan" name="infinispan-build-configuration-parent" version="11.0.15.Final">
          <artifact name="infinispan-build-configuration-parent-11.0.15.Final.pom">
-            <sha256 value="b2f82dd670e70f378a780efea1053f0e660a825dbbfe8c6ca8ca996dfde3aaa0" origin="Generated by Gradle" reason="Artifact is not signed"/>
+            <sha256 value="b2f82dd670e70f378a780efea1053f0e660a825dbbfe8c6ca8ca996dfde3aaa0" origin="Generated by Gradle"/>
          </artifact>
       </component>
       <component group="org.infinispan" name="infinispan-build-configuration-parent" version="13.0.12.Final">
@@ -246,12 +1467,938 @@
       </component>
       <component group="org.jboss" name="jboss-parent" version="36">
          <artifact name="jboss-parent-36.pom">
-            <sha256 value="000dd616298aebd21a9d5731874df083d7298424b91e037b73cbdd07ebc83e0e" origin="Generated by Gradle" reason="Artifact is not signed"/>
+            <sha256 value="000dd616298aebd21a9d5731874df083d7298424b91e037b73cbdd07ebc83e0e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains" name="annotations" version="13.0">
+         <artifact name="annotations-13.0.jar">
+            <sha256 value="ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="annotations-13.0.pom">
+            <sha256 value="965aeb2bedff369819bdde1bf7a0b3b89b8247dd69c88b86375d76163bb8c397" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.intellij.deps" name="trove4j" version="1.0.20200330">
+         <artifact name="trove4j-1.0.20200330.jar">
+            <sha256 value="c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="trove4j-1.0.20200330.pom">
+            <sha256 value="87721cbaa65a3c97d8b1ba9d207840f164c9fe38759fc9ea10ffe26565f8d3e9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-android-extensions" version="1.9.22">
+         <artifact name="kotlin-android-extensions-1.9.22.jar">
+            <sha256 value="1e5e881642a99ddb8f6d13e6995a08c192bc384187396663d8447c081d87e24f" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-android-extensions-1.9.22.pom">
+            <sha256 value="944b7cfb33e0a6fb684559048f028cb96326c932a245d5cb02143bcd2c031159" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-bom" version="1.6.21">
+         <artifact name="kotlin-bom-1.6.21.pom">
+            <sha256 value="cb2d2bf05031b16e227faa50c28f02bc36f86547d0cbea9d42c72ab24e3e5361" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-bom" version="1.9.22">
+         <artifact name="kotlin-bom-1.9.22.pom">
+            <sha256 value="188095a8341d66d22cf4b49944c0054e15a94bb8fb9b4eab2f661a6cb8c3e17e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-build-common" version="1.9.22">
+         <artifact name="kotlin-build-common-1.9.22.jar">
+            <sha256 value="53c3dcc5303f5903e6260aea73eccc6930f9a36efa2a11cd3bd3a7e55df63966" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-build-common-1.9.22.pom">
+            <sha256 value="297c5f498a077483ef89cd3a710cd2b7f2e5ae380f3a3aedfb9c41bc623b1340" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-build-tools-api" version="1.9.22">
+         <artifact name="kotlin-build-tools-api-1.9.22.jar">
+            <sha256 value="dd49cb7e28f4f3382f5250cfb05c864fd5f0a96d3265bb293c77b30adcc93ff6" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-build-tools-api-1.9.22.pom">
+            <sha256 value="0c564bbb87dc5ecdf6434d396eea1bf3ce976abf0881808dd166fa49b04649fb" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-build-tools-impl" version="1.9.22">
+         <artifact name="kotlin-build-tools-impl-1.9.22.jar">
+            <sha256 value="1b48d6de042a525f63b557513ae1266d699348225b013f940e32c63de2689428" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-build-tools-impl-1.9.22.pom">
+            <sha256 value="b5633f1349be95c74746e1e29a2aa6e752e89de1ab9a6523492f398fa69558dd" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-compiler-embeddable" version="1.9.22">
+         <artifact name="kotlin-compiler-embeddable-1.9.22.jar">
+            <sha256 value="2bfeadee59ab1988c336dbd6e65d991f766ae1dd8683f2a6ded5faa0279f0ca0" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-compiler-embeddable-1.9.22.pom">
+            <sha256 value="b3da34bb6f4296acf3a0f443466f0506c6c99da5cd9624d6e0b745b2228784eb" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-compiler-runner" version="1.9.22">
+         <artifact name="kotlin-compiler-runner-1.9.22.jar">
+            <sha256 value="73ec75bb99ebffa8b24a24a3b853f3f66096bc46a9351af0dac93debb69c15eb" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-compiler-runner-1.9.22.pom">
+            <sha256 value="a4ee8a67c1d6f253838c0027280bcb8050ac0dcdccad974896138a69a017eb01" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-daemon-client" version="1.9.22">
+         <artifact name="kotlin-daemon-client-1.9.22.jar">
+            <sha256 value="5d73e1815b1167e4afe208f00b2a75c080bc5a810786caadb8e14787593a93b9" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-daemon-client-1.9.22.pom">
+            <sha256 value="62c44a659da55db6fb125e2929b98d504a30e1f4af814e08e4921426aa524f8a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-daemon-embeddable" version="1.9.22">
+         <artifact name="kotlin-daemon-embeddable-1.9.22.jar">
+            <sha256 value="92a57813171447d534461fa13fe37dc8cd3b7f86d83e9b1f7bb1b0be30541f8b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-daemon-embeddable-1.9.22.pom">
+            <sha256 value="f6ea3dcf6bfb3a0d0698447c48a6bcf08d8eaacf83fc95fe9d4181a5e5e3c2b1" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-gradle-plugin" version="1.9.22">
+         <artifact name="kotlin-gradle-plugin-1.9.22-gradle82.jar">
+            <sha256 value="d4e718dd5f30c6ba932d93ccfc5b3015e9dd3e44143a052b877028f1fae542dc" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-gradle-plugin-1.9.22.module">
+            <sha256 value="a4f46ac0cabd8d5cdb689d2d37d19d58584f708bf9f64ffe4e980a2ff7534bb5" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-gradle-plugin-annotations" version="1.9.22">
+         <artifact name="kotlin-gradle-plugin-annotations-1.9.22.jar">
+            <sha256 value="967683cb98d9910145607fbf5b456295b43f0aaf93b1bba7bf6992e731cb24ec" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-gradle-plugin-annotations-1.9.22.pom">
+            <sha256 value="63ba68afe078ff70f708f9e979c693c45bfe89041f79641b0b81f6b4a126eebb" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-gradle-plugin-api" version="1.9.22">
+         <artifact name="kotlin-gradle-plugin-api-1.9.22.jar">
+            <sha256 value="ecff67546065c60e095fb93b3f88b9b92ed1edc37e3febbc6f9ed35422fa412b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-gradle-plugin-api-1.9.22.module">
+            <sha256 value="1f4489c5304f9a512a5687ffcc0aaf0930afc9d72051d3a905fac0700362fb7b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-gradle-plugin-idea" version="1.9.22">
+         <artifact name="kotlin-gradle-plugin-idea-1.9.22.jar">
+            <sha256 value="8d1af87632d95148f122a9fa0ae2903c19ee6fab7d01e017f76e0d2c9a022c20" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-gradle-plugin-idea-1.9.22.module">
+            <sha256 value="cfe2c26e330f68032c003fa524c031e5a60fce8d899fff2e42314128beb4402b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-gradle-plugin-idea-proto" version="1.9.22">
+         <artifact name="kotlin-gradle-plugin-idea-proto-1.9.22.jar">
+            <sha256 value="f5d82ee61966a2d98adfae19f24d6173022c15404896cdf236340035ee68c0f5" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-gradle-plugin-idea-proto-1.9.22.pom">
+            <sha256 value="86e32ca82927da880a1cf343a40ecc2098075e6fd72273b34d50dfa544f3463b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-gradle-plugin-model" version="1.9.22">
+         <artifact name="kotlin-gradle-plugin-model-1.9.22.jar">
+            <sha256 value="5108fad5be149825ece3a00103c3c21cf1afe954bb64b870789572939d7538cb" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-gradle-plugin-model-1.9.22.module">
+            <sha256 value="2ff3013df2ba7a9b5e8b004e8481750c8d0fa953ad007a196d85d263671dbeae" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-gradle-plugins-bom" version="1.9.22">
+         <artifact name="kotlin-gradle-plugins-bom-1.9.22.module">
+            <sha256 value="423e34d61d220b1a0ddc1814086a8ceab4dad9e77902b0ce8cb4721bbf3dc6ed" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-gradle-plugins-bom-1.9.22.pom">
+            <sha256 value="75adbf5c78ce247c22baf3628d0b3ff1cf7ed7d37d601eba7304d77ab75bdd9f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-klib-commonizer-api" version="1.9.22">
+         <artifact name="kotlin-klib-commonizer-api-1.9.22.jar">
+            <sha256 value="8c2f65429c182e2e4a2e09cb910e62b96db6eed285594b8f81af823b7e5944e2" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-klib-commonizer-api-1.9.22.pom">
+            <sha256 value="10cac970d300a3489c33f0b304156ff032d95959be5aaac3b880282ad58622fe" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-klib-commonizer-embeddable" version="1.9.22">
+         <artifact name="kotlin-klib-commonizer-embeddable-1.9.22.jar">
+            <sha256 value="73fe743e74d21283d383d0babe85fd08c442afc1a7bd88082f8da0510d053d4b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-klib-commonizer-embeddable-1.9.22.pom">
+            <sha256 value="77182122da697b662a4913d7dd9fe6bbaf004ce847fd867da23eaff0c4c8244b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-native-utils" version="1.9.22">
+         <artifact name="kotlin-native-utils-1.9.22.jar">
+            <sha256 value="786c127dd5535db2c39ae597cd0b0cad9e914b83e236f1db0251235cc9c652ac" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-native-utils-1.9.22.pom">
+            <sha256 value="11c514c05eea3ae9e8e16ab49796f111df43c7348231e35faf4c428cc4f743ea" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-project-model" version="1.9.22">
+         <artifact name="kotlin-project-model-1.9.22.jar">
+            <sha256 value="cc11d5c0b1909c5b0a08fd25ef0e754ffd2bf56caef665fb785122235e542a18" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-project-model-1.9.22.pom">
+            <sha256 value="eb9f4a16781bfc00ccec8030fbe5ee228e6f2b2771c50c267b3218feb0065b40" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-reflect" version="1.6.10">
+         <artifact name="kotlin-reflect-1.6.10.jar">
+            <sha256 value="3277ac102ae17aad10a55abec75ff5696c8d109790396434b496e75087854203" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-reflect-1.6.10.pom">
+            <sha256 value="57905524274a00ae028aaccc27283f6bc5925a934a046c1cc5d06c8ee4d6d5a9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-script-runtime" version="1.9.22">
+         <artifact name="kotlin-script-runtime-1.9.22.jar">
+            <sha256 value="b80670579f7f92d473d8d5834f0b124f7755c4598fe94b244183b02834834574" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-script-runtime-1.9.22.pom">
+            <sha256 value="feb6b49ecf69106d4c1285e71f9a1bda7a127cef68302e3e9fdc8298a4e34795" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-scripting-common" version="1.9.22">
+         <artifact name="kotlin-scripting-common-1.9.22.jar">
+            <sha256 value="fa500cbf034943ef8126f3d3dc65af09ff99dfffe44c5099b4fc2ed5bf2f5dc7" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-scripting-common-1.9.22.pom">
+            <sha256 value="44e51123b0c27e6fd933fc266b4d0daf0f0684a62aed9fe6842e8da33f2a2b3f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-scripting-compiler-embeddable" version="1.9.22">
+         <artifact name="kotlin-scripting-compiler-embeddable-1.9.22.jar">
+            <sha256 value="223fec84830234499cd4c7a23ea1c92eba127c41b35d9bb1d4b61d24155aeb35" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-scripting-compiler-embeddable-1.9.22.pom">
+            <sha256 value="c1608f3fbcb2a9f7523ead33599c2eadce4c812161a9e066b9f4b005af7b431c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-scripting-compiler-impl-embeddable" version="1.9.22">
+         <artifact name="kotlin-scripting-compiler-impl-embeddable-1.9.22.jar">
+            <sha256 value="38991816a287ff76241f1a77e7f1116481d4e93a3db63259a657dde20e6d0f65" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-scripting-compiler-impl-embeddable-1.9.22.pom">
+            <sha256 value="82671c33a957b2e2a820d66a692c2fce63e3bf047f1cb25e6fb0391c5ddcf2e7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-scripting-jvm" version="1.9.22">
+         <artifact name="kotlin-scripting-jvm-1.9.22.jar">
+            <sha256 value="8d127d76fcfa0517c36c1ea0e228ece03d5a4682642a01f6479a6bbdc7312a29" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-scripting-jvm-1.9.22.pom">
+            <sha256 value="701252ea1ba8ff87fc33476a61e3d5c6d9d2dda41baa98994dd6980ee13fbc6d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-stdlib" version="1.9.20">
+         <artifact name="kotlin-stdlib-1.9.20.jar">
+            <sha256 value="28a35bcdff46d864f80f346a617e486284b208d17378c41900dfb1de95a90e6c" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-stdlib-1.9.20.module">
+            <sha256 value="dccaa5d315470fab3920502886bbb85f2da6c86102c65d9c04410544eedb2019" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-stdlib" version="1.9.22">
+         <artifact name="kotlin-stdlib-1.9.22-all.jar">
+            <sha256 value="cec38bc3302e72a8aaf9cde436b5a9071ee0331e2ad05e84d8bb897334d7e9d4" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-stdlib-1.9.22.jar">
+            <sha256 value="6abe146c27864138b874ccccfe5f534e3eb923c99a1b7b5d45494ee5694f3e0a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-stdlib-1.9.22.module">
+            <sha256 value="f482314b5079c1455f6fb0d4257a745d101c6124ce961522ba86f9dc90901e47" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-stdlib-common" version="1.9.22">
+         <artifact name="kotlin-stdlib-common-1.9.22.module">
+            <sha256 value="f93c9e9abf8d52d8e8fd8e851aa802ecec55132161c4aeee7d3cd924bf794246" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-stdlib-jdk7" version="1.8.21">
+         <artifact name="kotlin-stdlib-jdk7-1.8.21.jar">
+            <sha256 value="33d148db0e11debd0d90677d28242bced907f9c77730000fd597867089039d86" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-stdlib-jdk7-1.8.21.pom">
+            <sha256 value="9bb107d5d5e3930bc5977f007a43cd20b7d24d91b1c1e528ea6ee0f248f14d36" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-stdlib-jdk7" version="1.9.10">
+         <artifact name="kotlin-stdlib-jdk7-1.9.10.jar">
+            <sha256 value="ac6361bf9ad1ed382c2103d9712c47cdec166232b4903ed596e8876b0681c9b7" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-stdlib-jdk7-1.9.10.pom">
+            <sha256 value="c7fa67c7961320b89d85a3ca59a2e18c2c65850845595dcae4b46af6945edcd5" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-stdlib-jdk7" version="1.9.22">
+         <artifact name="kotlin-stdlib-jdk7-1.9.22.jar">
+            <sha256 value="f91f24cfad3a756688a35129e5f335480d0eb408f1568a17f707c289f8769bdd" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-stdlib-jdk7-1.9.22.pom">
+            <sha256 value="4879ca8102833c8ada3f46c77a9ffafae1970cafc0bc621f51201b6ad974ce9d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-stdlib-jdk8" version="1.8.21">
+         <artifact name="kotlin-stdlib-jdk8-1.8.21.jar">
+            <sha256 value="3db752a30074f06ee6c57984aa6f27da44f4d2bbc7f5442651f6988f1cb2b7d7" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-stdlib-jdk8-1.8.21.pom">
+            <sha256 value="3839d728d7c309a5c368b0270b44b4f1c7878ff5ca5d32a9a204faa3491459d8" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-stdlib-jdk8" version="1.9.10">
+         <artifact name="kotlin-stdlib-jdk8-1.9.10.jar">
+            <sha256 value="a4c74d94d64ce1abe53760fe0389dd941f6fc558d0dab35e47c085a11ec80f28" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-stdlib-jdk8-1.9.10.pom">
+            <sha256 value="5f4b94dd3065a7764c37fa15de2ad6d81f40d59f8cb33f17d181c6384fb7a72e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-stdlib-jdk8" version="1.9.22">
+         <artifact name="kotlin-stdlib-jdk8-1.9.22.jar">
+            <sha256 value="47046c3edc32fe0db1a36bfe3d3822958bb5be4411c5ba80f3ae895a3ec27291" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-stdlib-jdk8-1.9.22.pom">
+            <sha256 value="c94048259c6d0007578baafeb71ef8ff7badeb08f2d59437fc39651e0fb7f7ab" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-tooling-core" version="1.9.22">
+         <artifact name="kotlin-tooling-core-1.9.22.jar">
+            <sha256 value="8938eb97e36320daa3e6fb2a60fd2a05b232ff4a557173c5019f045b8832d9f4" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-tooling-core-1.9.22.pom">
+            <sha256 value="14fc7f35c635e5fcd1bea537ab4fa44312e843252d5333519e36b125ea089b21" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-util-io" version="1.9.22">
+         <artifact name="kotlin-util-io-1.9.22.jar">
+            <sha256 value="f6d7a58491a378b083ad1bead488a485e11d160b31e76c18c1ad520f1d28f46b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-util-io-1.9.22.pom">
+            <sha256 value="64fd6a20d6ec04013bb6d75627f6580bb73641d948909d5c1664e2e773106dee" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin" name="kotlin-util-klib" version="1.9.22">
+         <artifact name="kotlin-util-klib-1.9.22.jar">
+            <sha256 value="a679ee2f510f3ab92691818de5eb5b0902e86d88c97674e7db44dc4f2252c5f9" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlin-util-klib-1.9.22.pom">
+            <sha256 value="0dea7dfff0a2b74088ac997043cbc240835d2bff59b39fcc8b0cac6ea3eb3697" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlin.jvm" name="org.jetbrains.kotlin.jvm.gradle.plugin" version="1.9.22">
+         <artifact name="org.jetbrains.kotlin.jvm.gradle.plugin-1.9.22.pom">
+            <sha256 value="09cb02587fbe5fbe0719ae022265f6ba0befe643de6e7698d6fd81c02440049f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlinx" name="kotlinx-coroutines-bom" version="1.6.4">
+         <artifact name="kotlinx-coroutines-bom-1.6.4.pom">
+            <sha256 value="ab2614855fba66aa8a42514dbe3d5a884315ffe1ed63f5932e710a8006245ce1" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.jetbrains.kotlinx" name="kotlinx-coroutines-core-jvm" version="1.5.0">
+         <artifact name="kotlinx-coroutines-core-jvm-1.5.0.jar">
+            <sha256 value="78d6cc7135f84d692ff3752fcfd1fa1bbe0940d7df70652e4f1eaeec0c78afbb" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="kotlinx-coroutines-core-jvm-1.5.0.module">
+            <sha256 value="c885dd0281076c5843826de317e3cbcdc3d8859dbeef53ae1cfacd1b9c60f96e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.junit" name="junit-bom" version="5.10.0">
+         <artifact name="junit-bom-5.10.0.pom">
+            <sha256 value="e006dd8894f9fc7b75fc32bb12fe5ed8be65667d5b454f99e2e0b8c5bb8d30b3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.junit" name="junit-bom" version="5.7.1">
+         <artifact name="junit-bom-5.7.1.pom">
+            <sha256 value="0b9b14a3d62106fafe8c68a717b87b87ad18685899451b753c04fa41b6857784" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.junit" name="junit-bom" version="5.7.2">
+         <artifact name="junit-bom-5.7.2.pom">
+            <sha256 value="cd14aaa869991f82021c585d570d31ff342bcba58bb44233b70193771b96487b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.junit" name="junit-bom" version="5.8.2">
+         <artifact name="junit-bom-5.8.2.pom">
+            <sha256 value="836069ca9e8ee3c56e48376222da291263f137bd3fd16d84fdd47efcc3f286e2" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.junit" name="junit-bom" version="5.9.2">
+         <artifact name="junit-bom-5.9.2.module">
+            <sha256 value="ab137ba5a8e32c9b066bf9126a1c76dd5614b724ba5c0b02549772b5e9f4cf1f" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="junit-bom-5.9.2.pom">
+            <sha256 value="2ed07d65845131f5336a86476c9a4056b59d0b58b9815ab3679bb0f36f35f705" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.junit" name="junit-bom" version="5.9.3">
+         <artifact name="junit-bom-5.9.3.module">
+            <sha256 value="b401fd25901e582a524aa5343c4b39e28bc56e24961c1069bf2b4bbfcee46b93" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="junit-bom-5.9.3.pom">
+            <sha256 value="4d0329cd9e72f2420e5ca15724cbfe6ffa6e5fd2888361516271190fdc342ed7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.latencyutils" name="LatencyUtils" version="2.0.3">
+         <artifact name="LatencyUtils-2.0.3.jar">
+            <sha256 value="a32a9ffa06b2f4e01c5360f8f9df7bc5d9454a5d373cd8f361347fa5a57165ec" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="LatencyUtils-2.0.3.pom">
+            <sha256 value="8f0c0153790b84af6c09316d569bd106ee0f008b9393e80ba478f5bf65738a28" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.mockito" name="mockito-bom" version="4.5.1">
+         <artifact name="mockito-bom-4.5.1.pom">
+            <sha256 value="14bad55bcc2baf814c5fa494f9f6df0b4feed1ff1dc06a1d0155e3464db039c9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.reactivestreams" name="reactive-streams" version="1.0.4">
+         <artifact name="reactive-streams-1.0.4.jar">
+            <sha256 value="f75ca597789b3dac58f61857b9ac2e1034a68fa672db35055a8fb4509e325f28" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="reactive-streams-1.0.4.pom">
+            <sha256 value="54ba23d87a2d438540c99ef8794a0856fc573a256b498678283c3c67ef18ada8" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.slf4j" name="jul-to-slf4j" version="1.7.36">
+         <artifact name="jul-to-slf4j-1.7.36.jar">
+            <sha256 value="9e641fb142c5f0b0623d6222c09ea87523a41bf6bed48ac79940724010b989de" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="jul-to-slf4j-1.7.36.pom">
+            <sha256 value="99ff5340c4642a30829d3d98253f123e7a3ef573483164477c88d89d7e6586b7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.slf4j" name="slf4j-api" version="1.7.30">
+         <artifact name="slf4j-api-1.7.30.jar">
+            <sha256 value="cdba07964d1bb40a0761485c6b1e8c2f8fd9eb1d19c53928ac0d7f9510105c57" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="slf4j-api-1.7.30.pom">
+            <sha256 value="7e0747751e9b67e19dcb5206f04ea22cc03d250c422426402eadd03513f2c314" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.slf4j" name="slf4j-api" version="1.7.35">
+         <artifact name="slf4j-api-1.7.35.pom">
+            <sha256 value="2fb6434ed1c82e4ac78cd80043800b2bdb80a5c73aa65fc6b7de5fd5e42fd409" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.slf4j" name="slf4j-api" version="1.7.36">
+         <artifact name="slf4j-api-1.7.36.jar">
+            <sha256 value="d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="slf4j-api-1.7.36.pom">
+            <sha256 value="fb046a9c229437928bb11c2d27c8b5d773eb8a25e60cbd253d985210dedc2684" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.slf4j" name="slf4j-parent" version="1.7.30">
+         <artifact name="slf4j-parent-1.7.30.pom">
+            <sha256 value="11647956e48a0c5bfb3ac33f6da7e83f341002b6857efd335a505b687be34b75" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.slf4j" name="slf4j-parent" version="1.7.35">
+         <artifact name="slf4j-parent-1.7.35.pom">
+            <sha256 value="0912e868d5183a2de49dd5f53942531d294b2c05c24e838ca5ecda8bf0182389" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.slf4j" name="slf4j-parent" version="1.7.36">
+         <artifact name="slf4j-parent-1.7.36.pom">
+            <sha256 value="bb388d37fbcdd3cde64c3cede21838693218dc451f04040c5df360a78ed7e812" origin="Generated by Gradle"/>
          </artifact>
       </component>
       <component group="org.sonatype.oss" name="oss-parent" version="7">
          <artifact name="oss-parent-7.pom">
-            <sha256 value="b51f8867c92b6a722499557fc3a1fdea77bdf9ef574722fe90ce436a29559454" origin="Generated by Gradle" reason="Artifact is not signed"/>
+            <sha256 value="b51f8867c92b6a722499557fc3a1fdea77bdf9ef574722fe90ce436a29559454" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.sonatype.oss" name="oss-parent" version="9">
+         <artifact name="oss-parent-9.pom">
+            <sha256 value="fb40265f982548212ff82e362e59732b2187ec6f0d80182885c14ef1f982827a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework" name="spring-aop" version="5.3.24">
+         <artifact name="spring-aop-5.3.24.jar">
+            <sha256 value="8258621a15613b3a651a8305ddb488848ad502f6b147bc69eed553bb9ebf3426" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-aop-5.3.24.module">
+            <sha256 value="77cb8ccc41b1a904e65742de417c96fe816d276cbb074491850622e6f4e92c29" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework" name="spring-beans" version="5.3.24">
+         <artifact name="spring-beans-5.3.24.jar">
+            <sha256 value="19eb1978cc48c0c36d9902c16dfb608a2fcec9c822889280493a6ebb2ada4114" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-beans-5.3.24.module">
+            <sha256 value="2da6e947e8e69a69b386d7446b5939114e6ac683f28ee79ab9f89b7d78bd5480" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework" name="spring-context" version="5.3.24">
+         <artifact name="spring-context-5.3.24.jar">
+            <sha256 value="7e7bdee594a9fc17ccc46c9c584c793a2e1e3de4a819ba007e155a7e0769795e" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-context-5.3.24.module">
+            <sha256 value="48f1d59670a00366bafc312ebfc29fcace52c7503cf4ff7502bb00796ec0484a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework" name="spring-core" version="5.3.24">
+         <artifact name="spring-core-5.3.24.jar">
+            <sha256 value="7d513957395e6a354b80e714b31a52b765dd6c771b50a26419d277a06d13ea68" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-core-5.3.24.module">
+            <sha256 value="24bbba3cf3011be8668f5ba6d344cae2c8a1c8494ca1f15c31ec402f6ad73930" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework" name="spring-expression" version="5.3.24">
+         <artifact name="spring-expression-5.3.24.jar">
+            <sha256 value="05b0117e9bfb269a1803f08020787591930a8c79ec0363e5081a1df8ebe26c7b" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-expression-5.3.24.module">
+            <sha256 value="3315f33e8b44da4849aa0a2869ce79dd344e8b82dbded9d4deb8c28e4133f62b" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework" name="spring-framework-bom" version="5.3.24">
+         <artifact name="spring-framework-bom-5.3.24.pom">
+            <sha256 value="535213566bbbefe2636a0d4e8dd1a73ade612e2430c8ffd310dcc2a3b3b9ba41" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework" name="spring-jcl" version="5.3.24">
+         <artifact name="spring-jcl-5.3.24.jar">
+            <sha256 value="a62d125552e7c8d438145ea31af6b027be244e631fea5ebb3c62f60147afd7ae" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-jcl-5.3.24.module">
+            <sha256 value="ac0f3ac672fe9f3c88eaa1c3d6c75461aea1936496ef26661f4ccd2c4a8764b4" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework" name="spring-web" version="5.3.24">
+         <artifact name="spring-web-5.3.24.jar">
+            <sha256 value="d7e9b62ae99354b84e42c0a61efd70e384c6cecd9354408b9c1a3002fed3d5fc" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-web-5.3.24.module">
+            <sha256 value="5e296cc5234eed4bc72152afaba54b205d6ad39262c886e1a2a94ecc0d616ae0" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework" name="spring-webmvc" version="5.3.24">
+         <artifact name="spring-webmvc-5.3.24.jar">
+            <sha256 value="913d82ea870b257a052ed9b88e8d76d2af5d680c7f52264fbbfc6aae86b4e72d" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-webmvc-5.3.24.module">
+            <sha256 value="56353436f7d462b4ac11c8a7de9476ca6fc6cb990d387012b4cecb1f5fe331d7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot" version="2.7.6">
+         <artifact name="spring-boot-2.7.6.jar">
+            <sha256 value="c05734fa43b0c1148645ae6eb2ea1c452efe7d7d4e006c72aedb3baed0e6aa28" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-2.7.6.module">
+            <sha256 value="110ac8a245ae090b3e4fd8583565f4895a8783e2926856ef47ceb094352f7567" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-actuator" version="2.7.6">
+         <artifact name="spring-boot-actuator-2.7.6.jar">
+            <sha256 value="3c863a9579646ce3619a12d0c7d048d028cdaeaf044aafb2a86f5d9c5db6f0ab" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-actuator-2.7.6.module">
+            <sha256 value="0d0353d0290ec107b6d0f3ccaa7afdc9ca926fdf0df58bf3aa92a766207c2689" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-actuator-autoconfigure" version="2.7.6">
+         <artifact name="spring-boot-actuator-autoconfigure-2.7.6.jar">
+            <sha256 value="1782317af91f263ba2d76c630daf011b10d5ed1321a83a902c36c97277563b5c" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-actuator-autoconfigure-2.7.6.module">
+            <sha256 value="f0220ff066d544e01e8b0dc6111a983c9cbc1d762b413bc4fa145f79ed081da6" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-autoconfigure" version="2.7.6">
+         <artifact name="spring-boot-autoconfigure-2.7.6.jar">
+            <sha256 value="96898c378f0ef9c52af3e6e1b0686b0782b4752c9fbbb64df457986e1cec4086" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-autoconfigure-2.7.6.module">
+            <sha256 value="704fa7b13e50705730c960f7981adcc0115ae64d80a9a27cdfa6859cc4867ae7" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-dependencies" version="2.7.6">
+         <artifact name="spring-boot-dependencies-2.7.6.pom">
+            <sha256 value="77b8d94f1df7e2dbf64020424b0f9ec6312b065b6bc47ab078702a56f31a0951" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-starter" version="2.7.6">
+         <artifact name="spring-boot-starter-2.7.6.jar">
+            <sha256 value="bbfad5d367c08e8541ccb33699bce7114b0e7d3f5be895069683e24a05d3bff8" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-starter-2.7.6.module">
+            <sha256 value="d0bc59399ca9dc4d8c2a9a242857425722933917bf00bed5f238090fd81fd078" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-starter-actuator" version="2.7.6">
+         <artifact name="spring-boot-starter-actuator-2.7.6.jar">
+            <sha256 value="62c2a458648c5f91c9cff1a554ccfcd5fc4b10c1b47242b07a188fc2d6267af6" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-starter-actuator-2.7.6.module">
+            <sha256 value="d2ed5951f5dd38b1d9e3d94f32600f9cd5dac8abc3553f4e1221a5ebdd2818ff" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-starter-jetty" version="2.7.6">
+         <artifact name="spring-boot-starter-jetty-2.7.6.jar">
+            <sha256 value="b20ca9d7ebd08537df35bad1cc9c06d8d2109b55b80bc552d96555a9d68dcc1e" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-starter-jetty-2.7.6.module">
+            <sha256 value="f436d176fbea0e55caa52e92bf193a58eb9c9d9e506fdb99362cc89b908c1dd1" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-starter-json" version="2.7.6">
+         <artifact name="spring-boot-starter-json-2.7.6.jar">
+            <sha256 value="30de6cae5af37ce7d10325857e19f9291deefb997324fd37de8735dfad82d147" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-starter-json-2.7.6.module">
+            <sha256 value="7733957ce91d58e929665b2ab425aae8e5201e4a7794277cc92c8eec66fa0dc4" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-starter-logging" version="2.7.6">
+         <artifact name="spring-boot-starter-logging-2.7.6.jar">
+            <sha256 value="83264e08ae877e9c25ee5a804b683087d2697c825d41e615a5aa151f039c506e" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-starter-logging-2.7.6.module">
+            <sha256 value="c09a856f654829539091b273af423470d096197fb6efe8611295604aa5467316" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-starter-parent" version="2.7.6">
+         <artifact name="spring-boot-starter-parent-2.7.6.pom">
+            <sha256 value="0a911abb0ba3ed4b73dcda67fcb74458cf77d49c9d945ef257e0776d2e6f8d10" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.boot" name="spring-boot-starter-web" version="2.7.6">
+         <artifact name="spring-boot-starter-web-2.7.6.jar">
+            <sha256 value="a66e4acdb267b27fd295965340cf55d7da898db2c40bdf5f27297743de954b80" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="spring-boot-starter-web-2.7.6.module">
+            <sha256 value="c5a4cb975a29e4b784b53b10698cfc5639497b8d7543f8a1ed626f78d10eeafc" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.data" name="spring-data-bom" version="2021.2.6">
+         <artifact name="spring-data-bom-2021.2.6.pom">
+            <sha256 value="0737ba59e0a7eb0e01c7657e116538ebe4edb16acd9d8ca385bd69d16d8134f6" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.integration" name="spring-integration-bom" version="5.5.15">
+         <artifact name="spring-integration-bom-5.5.15.pom">
+            <sha256 value="aaba524573191a83c3f5ed08c6af37cd959c8b7fba63a1c4067bd018cca91780" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.security" name="spring-security-bom" version="5.7.5">
+         <artifact name="spring-security-bom-5.7.5.pom">
+            <sha256 value="ac4f61591666441dc125b52111e9039580bdba0ae2b1d7234760e4b807eb28cb" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.springframework.session" name="spring-session-bom" version="2021.2.0">
+         <artifact name="spring-session-bom-2021.2.0.pom">
+            <sha256 value="fc39fa437dae72f38e77ff66874ec2798822ebf126a50ab8ee1c67f9376f9afd" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.testcontainers" name="testcontainers-bom" version="1.16.1">
+         <artifact name="testcontainers-bom-1.16.1.pom">
+            <sha256 value="5061ba84c98536e5a6b4ce280fbcecb00e335f3b04c5d484629162fcb4624778" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.threeten" name="threetenbp" version="1.6.8">
+         <artifact name="threetenbp-1.6.8.jar">
+            <sha256 value="e4b1eb3d90c38a54c7f3384fda957e0b5bf0b41b40672a44ae8b03cb6c87ce06" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="threetenbp-1.6.8.pom">
+            <sha256 value="ced3339d800d1bbc01ee672df80e4da87520ae0297b9aac8f8c4b7dda23e4b02" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="org.yaml" name="snakeyaml" version="1.30">
+         <artifact name="snakeyaml-1.30.jar">
+            <sha256 value="f43a4e40a946b8cdfd0321bc1c9a839bc3f119c57e4ca84fb87c367f51c8b2b3" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="snakeyaml-1.30.pom">
+            <sha256 value="d3e5fdff90ec58d37fd2b696230f3456f0d8f8e1d5e9ee911b19e6904ae0ebfe" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="annotations" version="2.25.0">
+         <artifact name="annotations-2.25.0.jar">
+            <sha256 value="3fd879fde2ce0fbbced7fe36e052e3d882a77ac0f49490ac160cdf6a1ee0ee41" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="annotations-2.25.0.pom">
+            <sha256 value="2ab689348271ae06572a38886521c7fe9c69047946e1ebf6293df1cd02d45dcd" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="apache-client" version="2.25.0">
+         <artifact name="apache-client-2.25.0.jar">
+            <sha256 value="0a103ec23e6cdf5f25cf20e00a0e2a8e6d126631eab2fcade247ceb99b45cbf7" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="apache-client-2.25.0.pom">
+            <sha256 value="5c46c7a0803fc9512e7658c1a6db9131b951325164515fba8cf6b368fbdfb3d9" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="arns" version="2.25.0">
+         <artifact name="arns-2.25.0.jar">
+            <sha256 value="7c9cb66bc2a974664a304204cafb16061c1d1fb44c814b1057a9dbe746432111" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="arns-2.25.0.pom">
+            <sha256 value="5e2c1193bc3245a1141e2b710bfc317d1835fe62818ec63c0c80fffd1597fed8" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="auth" version="2.25.0">
+         <artifact name="auth-2.25.0.jar">
+            <sha256 value="7c96fac08236b3be3ff805f1f55a938742b993ee92ec00420c92a431d39e395a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="auth-2.25.0.pom">
+            <sha256 value="01ea6457c2be3906477dfdd8cd71c3abde38979809dd5c19b4b3820d49bb3074" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="aws-core" version="2.25.0">
+         <artifact name="aws-core-2.25.0.jar">
+            <sha256 value="2d65fb5707e9937c37f9e7613fa925bf5fff5711e2ed3c3d1b0e4720c8641934" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="aws-core-2.25.0.pom">
+            <sha256 value="544662dd46f1728c6b0d498a8669665cb50aa443d9b6dd55dd46c5f408ecffc5" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="aws-json-protocol" version="2.25.0">
+         <artifact name="aws-json-protocol-2.25.0.jar">
+            <sha256 value="d5d3bc8daf46e5655e5ddb2826ce52b290b8bcf62505c1fb9a57e5576a72f6f1" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="aws-json-protocol-2.25.0.pom">
+            <sha256 value="12bdd013a2a27b9ebe7433b2afbd76b51a4818474f639679af8f8c4e3b3a05e4" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="aws-query-protocol" version="2.25.0">
+         <artifact name="aws-query-protocol-2.25.0.jar">
+            <sha256 value="ddab83406c6d75e188f7ba396e1a70a00e5070426b1cf230b7eae3e9aa93d049" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="aws-query-protocol-2.25.0.pom">
+            <sha256 value="0bc3a314fe7c72e82d3fb42587f188fee1e070847b64256384320f19da1befd4" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="aws-sdk-java-pom" version="2.25.0">
+         <artifact name="aws-sdk-java-pom-2.25.0.pom">
+            <sha256 value="f249fdfaef84ab291b18c1d0c5e9b502125a40ede4a66a60ee2dceee658c6399" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="aws-xml-protocol" version="2.25.0">
+         <artifact name="aws-xml-protocol-2.25.0.jar">
+            <sha256 value="c22e20d72083e5642b71192d3f3c8a34c9344f4bd54a5a197d6905c4df8eb8f0" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="aws-xml-protocol-2.25.0.pom">
+            <sha256 value="403599756218b3170b2fcb30c21452585d88bc335d9ec745f9ee0f4abcb0a9dd" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="bom" version="2.25.0">
+         <artifact name="bom-2.25.0.pom">
+            <sha256 value="1e64ff4110112fc36abd5056c131653821107d98032a5d77453ff143d3fda2d3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="bom-internal" version="2.25.0">
+         <artifact name="bom-internal-2.25.0.pom">
+            <sha256 value="e9d22b7138aeb7484bb5ea7d5a941f9279edb2697e82c5f3c1e85f847a3dd5a2" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="checksums" version="2.25.0">
+         <artifact name="checksums-2.25.0.jar">
+            <sha256 value="d3a211b5f2d070edb35fcfdc776760c879355148915eb94c80dbf19a70f59bde" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="checksums-2.25.0.pom">
+            <sha256 value="a69360be43368b0d2b55a642eaa47d10434effc78fedbc92a4ea9031136a9a83" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="checksums-spi" version="2.25.0">
+         <artifact name="checksums-spi-2.25.0.jar">
+            <sha256 value="6eee43204d6694da31c782881eaa9a12008328dbe40b4cb9d5f4d0d679ac972c" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="checksums-spi-2.25.0.pom">
+            <sha256 value="a724fce2ad1ad4156f28ca53050317f8ad9d965fe90ae417b95f4d0d42d9b777" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="core" version="2.25.0">
+         <artifact name="core-2.25.0.pom">
+            <sha256 value="6f6c9db52e871d189d4c3b7de184b5df3afafb4e752b630df67c376ffe470b05" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="crt-core" version="2.25.0">
+         <artifact name="crt-core-2.25.0.jar">
+            <sha256 value="0a423f285f1eb7b0223c62749bc5f2f90802e561fd29b4d7088114a8786762ac" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="crt-core-2.25.0.pom">
+            <sha256 value="bec82685ac5f9d7fcc587d764d01aead54380cb17c506f1805b76b289359baa3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="endpoints-spi" version="2.25.0">
+         <artifact name="endpoints-spi-2.25.0.jar">
+            <sha256 value="839ee253aa0ee2d1475feb2b23312617a3e6ab0e72c77fb80638346f4509bd08" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="endpoints-spi-2.25.0.pom">
+            <sha256 value="480d12088a035f847bcea839822995a1a4f0610a453bb1dc0ab58c6fff6ff0d3" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="http-auth" version="2.25.0">
+         <artifact name="http-auth-2.25.0.jar">
+            <sha256 value="8fda83b76af3c56d82aadacac361b804a11ac495c28ae6079fb3bd0e7124d54c" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="http-auth-2.25.0.pom">
+            <sha256 value="96543a369d7664424cdc3a30588d7f4105b4b20db2b0197f257f068e3da2847f" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="http-auth-aws" version="2.25.0">
+         <artifact name="http-auth-aws-2.25.0.jar">
+            <sha256 value="c7ca1457b099abc01acd84dbc5faa6b2eac6dab33a71d870342e1182d5fc7fc2" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="http-auth-aws-2.25.0.pom">
+            <sha256 value="3c3474a7bb737203738094f3e83aa9a990de2bb2d34b205897680b56acffd34a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="http-auth-spi" version="2.25.0">
+         <artifact name="http-auth-spi-2.25.0.jar">
+            <sha256 value="1405b291537c318d11b0c67f8b1fdccb6201f4f7558b8f15f2c085de22f2983c" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="http-auth-spi-2.25.0.pom">
+            <sha256 value="cfc54c1b5c3c7f0c847c5876129c8562b649a04e0bf51927f12ac39f7ed936f2" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="http-client-spi" version="2.25.0">
+         <artifact name="http-client-spi-2.25.0.jar">
+            <sha256 value="33e16dcbe1db4b428055c9e9ee0ea44de68c652c0b8b4d29ce6ea2d6d4db8c3d" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="http-client-spi-2.25.0.pom">
+            <sha256 value="99c365dfe48ff4bdb263aef762a18f080387c401314a1493fad532dea216904d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="http-clients" version="2.25.0">
+         <artifact name="http-clients-2.25.0.pom">
+            <sha256 value="961b6dbb9b7f754f2ccfe14e452039cc914e6b79377e673ff0ea644452dbdd69" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="identity-spi" version="2.25.0">
+         <artifact name="identity-spi-2.25.0.jar">
+            <sha256 value="27a58bfc8cfc9a5dd63f808c293cfeabe22b6becb2716946d37608ec84cb9b06" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="identity-spi-2.25.0.pom">
+            <sha256 value="db8834eddf5a82845a3e0af1ccb3baf0806d42be7da8ad36ef2ab9dac63d0c2e" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="json-utils" version="2.25.0">
+         <artifact name="json-utils-2.25.0.jar">
+            <sha256 value="4c82efa71484e812d4da7cd20e3eec747f7ab17c68e9ab7b42563d2f3ccf4a68" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="json-utils-2.25.0.pom">
+            <sha256 value="83ae50debbd3e1fe8088c6f456fc9e7b9658de812eb97029bd15be40759f35a2" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="metrics-spi" version="2.25.0">
+         <artifact name="metrics-spi-2.25.0.jar">
+            <sha256 value="cf26bd7ea30f82b24f5ff90e3109486635b1e9bfd9cc145a96986fda9520383a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="metrics-spi-2.25.0.pom">
+            <sha256 value="93270b0c5439611a443612c61bbdb1e0e76a38c9905587417275374032d157f1" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="netty-nio-client" version="2.25.0">
+         <artifact name="netty-nio-client-2.25.0.jar">
+            <sha256 value="9bb8f3ee5c9774924855bc8e034630177bd773ba6a0343081d94cf16c43b24cd" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="netty-nio-client-2.25.0.pom">
+            <sha256 value="a29b56af20fef86e311f81bc7c9cbbf452853cd4c1ef12b634470002416ed95c" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="profiles" version="2.25.0">
+         <artifact name="profiles-2.25.0.jar">
+            <sha256 value="331a7eb9db0f6ae57f3a958550297f41e1de22f3b827dc1f033075b9691ad497" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="profiles-2.25.0.pom">
+            <sha256 value="baaf4f4cdb19fbdc19063b7c0cbdc5bafa9718e7224bce704bcfccb782a03cea" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="protocol-core" version="2.25.0">
+         <artifact name="protocol-core-2.25.0.jar">
+            <sha256 value="8dcd7983871c62c3485c26e7f122fc999385f834bec35ae72bc91796482ef775" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="protocol-core-2.25.0.pom">
+            <sha256 value="4ae867d32e534c168c9c8fbfa96f330b0d171baf60b3385e8b25d279ad92fc8d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="protocols" version="2.25.0">
+         <artifact name="protocols-2.25.0.pom">
+            <sha256 value="f51b488d276887036791803f1e1b4213ffb7c5b96d10c149f399bd85b32e8db0" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="regions" version="2.25.0">
+         <artifact name="regions-2.25.0.jar">
+            <sha256 value="35af6932fb30c85f2614140c488a90a0af02036e696192c931eee91b758bb44a" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="regions-2.25.0.pom">
+            <sha256 value="1c3ed8b6ea92ba7f4d95b68d853c6c5b8fff02bec39eac68c421dd5847eb4b42" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="s3" version="2.25.0">
+         <artifact name="s3-2.25.0.jar">
+            <sha256 value="54b52dbc88fc1214e96982b46674ae3fd4825127c9de7881e7d94ff675347b08" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="s3-2.25.0.pom">
+            <sha256 value="9957fd1a3c53372d7676749e732de25bdc98707d8d9ea685ca1262ec4fd2f06a" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="sdk-core" version="2.25.0">
+         <artifact name="sdk-core-2.25.0.jar">
+            <sha256 value="391e36fc8f4b182b7af442df9fcf0306681e138e11e04c8b16fc9122382cd735" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="sdk-core-2.25.0.pom">
+            <sha256 value="cbcde4a5ec8c78d24dee548b9b5c3b3478ae7f72fe4bfca640e5640fe24625dd" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="services" version="2.25.0">
+         <artifact name="services-2.25.0.pom">
+            <sha256 value="db9cee14f36090397bf670379d6851dbe9a36080eaaadb673fbfbcf752c94a7d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="sso" version="2.25.0">
+         <artifact name="sso-2.25.0.jar">
+            <sha256 value="c3c7b895127fe8a330e21b5bf8f05aebfe1150529e46b079afa8d478cb752d04" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="sso-2.25.0.pom">
+            <sha256 value="9ac9eb2513f5d28f8c7d0d0e5f26beb8a96f6bd6e28d2de2351ecfd02e3e5d26" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="sts" version="2.25.0">
+         <artifact name="sts-2.25.0.jar">
+            <sha256 value="7d36ed59f2dbd686c0715bbbbec59c3f3475215c245d84482fa6a40c05dd2545" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="sts-2.25.0.pom">
+            <sha256 value="a6ffc64f3f418fc90a0918631310862534f4a3958439f656d162f71ae5d9e41d" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="third-party" version="2.25.0">
+         <artifact name="third-party-2.25.0.pom">
+            <sha256 value="87a2ece80e2dfd9f622632dae7bf8f777f87f24b705a60490880428edbeb8700" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="third-party-jackson-core" version="2.25.0">
+         <artifact name="third-party-jackson-core-2.25.0.jar">
+            <sha256 value="58ff298cac264c7cf0ea9318bf0d22df86a1dec4ce72ed5720a674da5b3a40bb" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="third-party-jackson-core-2.25.0.pom">
+            <sha256 value="78812c303e696cc1b1627a567ccc0eca168851efde2cb92683c61ea0c0537fca" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.awssdk" name="utils" version="2.25.0">
+         <artifact name="utils-2.25.0.jar">
+            <sha256 value="6325bab0a9466df05323d30d66adb9b9c9458cb3d3f0b6f74d7e1254638fcc77" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="utils-2.25.0.pom">
+            <sha256 value="b995911d3bafe1a277c5844f76b743e2500d325456ffbbabc227b281c936a3d5" origin="Generated by Gradle"/>
+         </artifact>
+      </component>
+      <component group="software.amazon.eventstream" name="eventstream" version="1.0.1">
+         <artifact name="eventstream-1.0.1.jar">
+            <sha256 value="0c37d8e696117f02c302191b8110b0d0eb20fa412fce34c3a269ec73c16ce822" origin="Generated by Gradle"/>
+         </artifact>
+         <artifact name="eventstream-1.0.1.pom">
+            <sha256 value="f9460cb794a0a7af68277efb5769569e8e66515250276c37e62a7e8bd4b257cc" origin="Generated by Gradle"/>
          </artifact>
       </component>
    </components>

--- a/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3BuildCache.kt
+++ b/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3BuildCache.kt
@@ -31,6 +31,7 @@ abstract class S3BuildCache : RemoteGradleBuildCache() {
 
     /**
      * Whether to use reduced redundancy.
+     * When using S3 Express One Zone, set to false
      * @see <a href="https://aws.amazon.com/s3/reduced-redundancy/">Reduced Redundancy</a>
      * */
     var reducedRedundancy: Boolean = true

--- a/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3StorageService.kt
+++ b/s3buildcache/src/main/kotlin/androidx/build/gradle/s3buildcache/S3StorageService.kt
@@ -21,13 +21,15 @@ import androidx.build.gradle.core.FileHandleInputStream
 import androidx.build.gradle.core.FileHandleInputStream.Companion.handleInputStream
 import androidx.build.gradle.core.StorageService
 import org.gradle.api.logging.Logging
+import software.amazon.awssdk.core.exception.SdkException
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.StorageClass.REDUCED_REDUNDANCY
-import software.amazon.awssdk.services.s3.model.StorageClass.STANDARD
 import java.io.InputStream
 import kotlin.io.path.outputStream
 
@@ -74,7 +76,11 @@ class S3StorageService(
         val request = PutObjectRequest.builder()
             .bucket(bucketName)
             .key(cacheKey)
-            .storageClass(if (reducedRedundancy) REDUCED_REDUNDANCY else STANDARD)
+            .apply {
+                if (reducedRedundancy) {
+                    storageClass(REDUCED_REDUNDANCY)
+                }
+            }
             .build()
         logger.info("Storing $cacheKey via $request")
         return store(client, request, contents)
@@ -101,11 +107,13 @@ class S3StorageService(
 
     override fun validateConfiguration() {
         try {
-            val buckets = client.listBuckets().buckets()
-            if (buckets.none { bucket -> bucket.name() == bucketName }) {
-                throw Exception("Bucket $bucketName under project $region cannot be found or is not accessible using the provided credentials")
-            }
-        } catch (e: Exception) {
+            client.headBucket(HeadBucketRequest.builder().bucket(bucketName).build())
+        }  catch(e: NoSuchBucketException) {
+            throw Exception("Bucket $bucketName in $region cannot be found: ${e.message}")
+        } catch  (e: SdkException ) {
+            throw Exception("AWS SDK exception on validating access to $bucketName in $region: ${e.message}")
+        }
+        catch (e: Exception) {
             logger.warn("Couldn't validate S3 client config: ${e.message}")
         }
     }


### PR DESCRIPTION
https://aws.amazon.com/s3/storage-classes/express-one-zone/ is a new type of s3 bucket which offers better performance, lower cost for some use cases. It's mostly compatible with regular s3 api with a few caveats:

- listBuckets operation would not return buckets of s3 express one zone type (aka directory buckets)
- the objects in the bucket use their own storage class, so setting it explicitly to reduced redundancy/standard would cause a store request to fail.

This PR fixes both by:
 - swapping listBuckets operation to headBucket. This also: 
   - lowers the permissions required by the IAM role that the plugin attempts to use, as no listBucket permission is needed anymore
   - allows for cross-account bucket access without having to assume a role in the account owning the bucket (aws s3 allows cross account access to bucket objects, but that would not results in request to list all buckets to list ones in different accounts)
 - don't set the storage class in the putobject request if it's not set to reduced redundancy. this makes the storage class default to appropriate one depending on the type of the bucket (standard for s3, default express one zone class for directory buckets (which name I can't remember :)))

lmk if I missed anything in the PR, or anything you'd like changes.
I did change gradle/verification-metadata.xml by running `gradle xyz --write-verification-metadata sha256` but idk if that was the right thing to do, I might have not studied the gradle manual well enough (I thought the update is legit and caused by bumping the version of aws sdk as per `libs.versions.toml`)

---

Lastly, wanted to ask about error handling in the s3 cache and what's the rationale behind current implementation, which logs cache load/store errors (basically fails silently) instead of relying on throwing BuildCacheExceptions (and or other classes) and depending on gradle to fail the build/disable the cache as needed. 


I'm referring to the following parts of gradle default http cache implementation:

 - https://sourcegraph.com/github.com/gradle/gradle@e841994a3207ab4aa59e46cdda3a9a84b576cbe9/-/blob/platforms/core-execution/build-cache-spi/src/main/java/org/gradle/caching/BuildCacheService.java?L41%3A18-41%3A35=
 - https://sourcegraph.com/github.com/gradle/gradle@e841994a3207ab4aa59e46cdda3a9a84b576cbe9/-/blob/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/internal/HttpBuildCacheService.java?L171%3A13-171%3A35=
   
lmk if this should be a separate issue, and or whether contributions are welcome, but I was thinking if it'd be ok to switch to using those. (I'd prefer explicit errors when storing objects fails for let's say auth reasons, but the same error handling pattern is present in gcp plugin so I'm not sure if there's a good reason behind that and whether you'd be fine with s3 handling it different than gcp)
