### PR TITLE
Promote s3-build-cache to v1.0.0-beta01

### DIFF
--- a/s3buildcache/build.gradle.kts
+++ b/s3buildcache/build.gradle.kts
@@ -57,7 +57,7 @@ gradlePlugin {
             id = "androidx.build.gradle.s3buildcache"
             displayName = "Gradle AWS S3 Build Cache Plugin"
             description = """
-                - Move to targeting Java 17
+                - Promote to v1.0.0-beta01.
             """.trimIndent()
             implementationClass = "androidx.build.gradle.s3buildcache.S3GradleBuildCachePlugin"
             tags = listOf("buildcache", "s3", "caching")
@@ -66,7 +66,7 @@ gradlePlugin {
 }
 
 group = "androidx.build.gradle.s3buildcache"
-version = "1.0.0-alpha06"
+version = "1.0.0-beta01"
 
 testing {
     suites {


### PR DESCRIPTION
We've been using this implementation for over a year and have had zero problems. Will promote it to beta for a little while, with the intention of going to stable at some point as well.