### PR TITLE
Move TokenInfo to gcpbuildcache project

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -21,13 +21,8 @@ plugins {
 
 dependencies {
     implementation(gradleApi())
-    implementation(platform(libs.okhttp.bom))
     api(platform(libs.kotlin.bom))
     api(libs.kotlin.stdlib)
-    implementation(libs.retrofit.core)
-    implementation(libs.retrofit.converter.gson)
-    implementation(libs.google.gson)
-    implementation(libs.okhttp)
 }
 
 kotlin {

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageService.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageService.kt
@@ -20,7 +20,6 @@ package androidx.build.gradle.gcpbuildcache
 import androidx.build.gradle.core.FileHandleInputStream
 import androidx.build.gradle.core.FileHandleInputStream.Companion.handleInputStream
 import androidx.build.gradle.core.StorageService
-import androidx.build.gradle.core.TokenInfoService
 import com.google.api.gax.retrying.RetrySettings
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.http.HttpTransportOptions

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/NetworkErrorInterceptor.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/NetworkErrorInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  *
  */
 
-package androidx.build.gradle.core
+package androidx.build.gradle.gcpbuildcache
 
 import okhttp3.Interceptor
 import okhttp3.Response
 import org.gradle.api.GradleException
 import java.io.IOException
 
-class NetworkErrorInterceptor : Interceptor{
+class NetworkErrorInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         return try {

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/TokenInfo.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/TokenInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  *
  */
 
-package androidx.build.gradle.core
+package androidx.build.gradle.gcpbuildcache
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -32,7 +32,8 @@ internal fun gson(config: GsonBuilder.() -> Unit = {}): Gson {
     config.invoke(builder)
     return builder.create()
 }
-interface TokenInfoService {
+
+internal interface TokenInfoService {
     @GET("/oauth2/v1/tokeninfo")
     fun tokenInfo(@Query("access_token") accessToken: String): Call<Unit>
 

--- a/s3buildcache/build.gradle.kts
+++ b/s3buildcache/build.gradle.kts
@@ -27,11 +27,6 @@ dependencies {
     // Bundle core library directly as we only get to publish one jar per plugin in Gradle Plugin Portal
     bundleInside(project(":core"))
     implementation(platform(libs.amazon.bom))
-    implementation(platform(libs.okhttp.bom))
-    implementation(libs.retrofit.core)
-    implementation(libs.retrofit.converter.gson)
-    implementation(libs.google.gson)
-    implementation(libs.okhttp)
     implementation(libs.amazon.s3)
     implementation(libs.amazon.sso)
     runtimeOnly(libs.amazon.sts) {


### PR DESCRIPTION
This class is not used by the s3buildcache plugin

Test: ./gradlew test