### PR TITLE
Move to using GRPC to fetch cache entries from GCP

### DIFF
--- a/gcpbuildcache/build.gradle.kts
+++ b/gcpbuildcache/build.gradle.kts
@@ -55,7 +55,7 @@ gradlePlugin {
             id = "androidx.build.gradle.gcpbuildcache"
             displayName = "Gradle GCP Build Cache Plugin"
             description = """
-                - Graduating to 1.0.0 stable version.
+                - Move to using GRPC to fetch cache entries from GCP. Local testing shows that it drops sequential download time by ~40%
             """.trimIndent()
             implementationClass = "androidx.build.gradle.gcpbuildcache.GcpGradleBuildCachePlugin"
             tags = listOf("buildcache", "gcp", "caching")
@@ -64,7 +64,7 @@ gradlePlugin {
 }
 
 group = "androidx.build.gradle.gcpbuildcache"
-version = "1.0.0"
+version = "1.0.1"
 
 testing {
     suites {

--- a/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageService.kt
+++ b/gcpbuildcache/src/main/kotlin/androidx/build/gradle/gcpbuildcache/GcpStorageService.kt
@@ -173,10 +173,11 @@ internal class GcpStorageService(
             ) ?: return null
             val retrySettings = RetrySettings.newBuilder()
             retrySettings.maxAttempts = 3
-            return StorageOptions.newBuilder().setCredentials(credentials)
+            return GrpcStorageOptions.newBuilder().setCredentials(credentials)
                 .setStorageRetryStrategy(StorageRetryStrategy.getUniformStorageRetryStrategy()).setProjectId(projectId)
                 .setRetrySettings(retrySettings.build())
-                .setTransportOptions(transportOptions)
+                .setEnableGrpcClientMetrics(false)
+                .setAttemptDirectPath(false)
                 .build()
         }
 


### PR DESCRIPTION
Local testing shows that it drops sequential download time by ~40% Compare:

Before patch: https://ge.androidx.dev/scans/performance?performance.metric=buildCacheOverhead%2CbuildCacheOverheadDownload&search.startTimeMax=1758610799999&search.startTimeMin=1758317400000&search.tags=nonGrpc&search.tasks=assemble&search.timeZoneId=America%2FLos_Angeles&search.usernames=aurimas

After patch: https://ge.androidx.dev/scans/performance?performance.metric=buildCacheOverhead,buildCacheOverheadDownload&search.startTimeMax=1758610799999&search.startTimeMin=1758316800000&search.tags=not:nonGrpc&search.tasks=assemble&search.timeZoneId=America%2FLos_Angeles&search.usernames=aurimas

Going from 13m 1s to 7m 54s in sequential download time.

Test was running the following in androidx checkout: rm -fr ../../out/.gradle/caches/build-cache-1/ && rm -fr ../../out/androidx && ALLOW_PUBLIC_REPOS=true ./gradlew -p compose assemble --dependency-verification=off