### PR TITLE
Ensure that androidx.build.gradle.gcpbuildcache support Gradle 8.4 or newer

### DIFF
--- a/gcpbuildcache/README.md
+++ b/gcpbuildcache/README.md
@@ -2,6 +2,10 @@
 
 An implementation of the Gradle Remote Cache that's backed by Google Cloud Storage buckets.
 
+## Requirements
+
+- Gradle 8.4 or newer
+
 ## Using the plugin
 
 In your `settings.gradle.kts` file add the following
@@ -12,7 +16,7 @@ import androidx.build.gradle.gcpbuildcache.GcpBuildCacheServiceFactory
 import androidx.build.gradle.gcpbuildcache.ExportedKeyGcpCredentials
 
 plugins {
-    id("androidx.build.gradle.gcpbuildcache") version "1.0.0"
+    id("androidx.build.gradle.gcpbuildcache") version "1.0.1"
 }
 
 buildCache {
@@ -35,7 +39,7 @@ If you are using Groovy, then you should do the following:
 
 ```groovy
 plugins {
-    id("androidx.build.gradle.gcpbuildcache") version "1.0.0"
+    id("androidx.build.gradle.gcpbuildcache") version "1.0.1"
 }
 
 import androidx.build.gradle.gcpbuildcache.GcpBuildCache

--- a/gcpbuildcache/build.gradle.kts
+++ b/gcpbuildcache/build.gradle.kts
@@ -41,10 +41,12 @@ kotlin {
     jvmToolchain {
         jvmToolchain(17)
     }
+    // Kotlin 1.9 is needed to support Gradle 8.4, if the value is changed, update README.md
     compilerOptions {
-        languageVersion.set(KotlinVersion.KOTLIN_2_0)
+        @Suppress("DEPRECATION") // 1.9 is deprecated when using KGP 2.2.20
+        languageVersion.set(KotlinVersion.KOTLIN_1_9)
     }
-    coreLibrariesVersion = "2.0.0"
+    coreLibrariesVersion = "1.9.0"
 }
 
 gradlePlugin {

--- a/gcpbuildcache/src/functionalTest/kotlin/androidx/build/gradle/gcpbuildcache/GcpGradleBuildCachePluginFunctionalTest.kt
+++ b/gcpbuildcache/src/functionalTest/kotlin/androidx/build/gradle/gcpbuildcache/GcpGradleBuildCachePluginFunctionalTest.kt
@@ -24,11 +24,28 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
 /**
  * A simple functional test for the 'androidx.build.gradle.gcpbuildcache.GcpBuildCache' plugin.
  */
-class GcpGradleBuildCachePluginFunctionalTest {
+@RunWith(Parameterized::class)
+class GcpGradleBuildCachePluginFunctionalTest(private val gradleVersion: String) {
+    companion object {
+        @get:JvmStatic
+        @get:Parameterized.Parameters(name = "gradleVersion={0}")
+        @Suppress("unused") // needed for Parameterized
+        val params = listOf(
+            arrayOf("8.4"),
+            arrayOf("8.5"),
+            arrayOf("8.11.1"),
+            arrayOf("8.14"),
+            arrayOf("9.0.0"),
+            arrayOf("9.1.0"),
+        )
+    }
+
     @get:Rule val tempFolder = TemporaryFolder()
 
     private fun getProjectDir() = tempFolder.root
@@ -56,11 +73,12 @@ class GcpGradleBuildCachePluginFunctionalTest {
         getBuildFile().writeText("")
 
         // Run the build
-        val runner = GradleRunner.create()
-        runner.forwardOutput()
-        runner.withPluginClasspath()
-        runner.withArguments("tasks")
-        runner.withProjectDir(getProjectDir())
-        runner.build();
+        GradleRunner.create()
+            .forwardOutput()
+            .withGradleVersion(gradleVersion)
+            .withPluginClasspath()
+            .withArguments("tasks", "-s")
+            .withProjectDir(getProjectDir())
+            .build();
     }
 }


### PR DESCRIPTION
- Expanded existing test to make sure it works correctly
- Moved kotlin language version back to 1.9 as it is needed for Gradle 8.4